### PR TITLE
Feature/project settings update

### DIFF
--- a/Hyperspace.xcodeproj/xcshareddata/xcschemes/Hyperspace_iOS.xcscheme
+++ b/Hyperspace.xcodeproj/xcshareddata/xcschemes/Hyperspace_iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0700"
+   LastUpgradeVersion = "0920"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
Ran Xcode-recommended project settings updates. There were not updates to be done so the version check flag was updated to Xcode 9.2 so we shouldn't see this warning pop up until the next version of Xcode is released.