### PR TITLE
Error handlingv2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ##### Enhancements
 
-* None.
+* Two new error-facing protocols were added. `NetworkServiceFailureInitializable` represents a `Swift.Error` that can be initialized from a `NetworkServiceFailure` object. `DecodingFailureInitializable` represents a `Swift.Error` that can be initialized from a `DecodingError` as a result of decoding `Data`. These conformances have been added as extensions to `AnyError` (meaning `AnyNetworkRequest` usage is unaffected). As a result of these new protocols, the `BackendServiceError` type has been removed. Types conforming to `NetworkRequest` now have an associated `ErrorType` which must conform to `NetworkServiceFailureInitializable`. If a request generates any sort of failure response, the custom error type will be initialized from it instead of returning a generic `BackendServiceError`. In addition, if `NetworkRequest.ErrorType` conforms to `DecodingFailureInitializable`, the custom erorr type will be instantiated and returned.
+    [Will McGinty](https://github.com/wmcginty)
+    [#38](https://github.com/BottleRocketStudios/iOS-Hyperspace/pull/38)
 
 ##### Bug Fixes
 

--- a/Sources/Hyperspace/Request/NetworkRequest.swift
+++ b/Sources/Hyperspace/Request/NetworkRequest.swift
@@ -40,7 +40,7 @@ public protocol NetworkServiceFailureInitializable: Swift.Error {
     init(networkServiceFailure: NetworkServiceFailure)
 }
 
-/// Represents an error which can be constructed from a `DecodingError`.
+/// Represents an error which can be constructed from a `DecodingError` and `Data`.
 public protocol DecodingFailureInitializable: Swift.Error {
     init(decodingError: DecodingError, data: Data)
 }
@@ -117,7 +117,7 @@ public struct NetworkRequestDefaults {
                 let decodedResponse: T = try decoder.decode(T.self, from: data)
                 return .success(decodedResponse)
             } catch {
-                guard let decodingError = error as? DecodingError else { fatalError("JSONDecoder should alsays throw a DecodingError.") }
+                guard let decodingError = error as? DecodingError else { fatalError("JSONDecoder should always throw a DecodingError.") }
                 return .failure(E(decodingError: decodingError, data: data))
             }
         }
@@ -191,7 +191,7 @@ extension AnyError: NetworkServiceFailureInitializable {
     }
 }
 
-// MARK: - AnyError Conformance to NetworkServiceInitializable
+// MARK: - AnyError Conformance to DecodingFailureInitializable
 
 extension AnyError: DecodingFailureInitializable {
     public init(decodingError: DecodingError, data: Data) {

--- a/Sources/Hyperspace/Request/NetworkRequest.swift
+++ b/Sources/Hyperspace/Request/NetworkRequest.swift
@@ -35,12 +35,22 @@ public enum NetworkRequestQueryParameterEncodingStrategy {
 }
 // swiftlint:enable type_name
 
+/// Represents an error which can be constructed from a `NetworkServiceFailure`.
+public protocol NetworkServiceFailureInitializable: Swift.Error {
+    init(networkServiceFailure: NetworkServiceFailure)
+}
+
+/// Represents an error which can be constructed from a `DecodingError`.
+public protocol DecodingFailureInitializable: Swift.Error {
+    init(decodingError: DecodingError, data: Data)
+}
+
 /// Encapsulates all the necessary parameters to represent a request that can be sent over the network.
 public protocol NetworkRequest {
     
     /// The model type that this NetworkRequest will attempt to transform Data into.
     associatedtype ResponseType
-    associatedtype ErrorType: Swift.Error
+    associatedtype ErrorType: NetworkServiceFailureInitializable
     
     /// The HTTP method to be use when executing this request.
     var method: HTTP.Method { get }
@@ -91,7 +101,7 @@ public struct EmptyResponse {
     public init() { }
 }
 
-// MARK: - NetworkRequest Default Implementations
+// MARK: - NetworkRequest Defaults
 
 public struct NetworkRequestDefaults {
     
@@ -101,17 +111,20 @@ public struct NetworkRequestDefaults {
     
     public static var defaultQueryParameterEncodingStrategy: NetworkRequestQueryParameterEncodingStrategy = .urlQueryAllowedCharacterSet
     
-    public static func dataTransformer<T: Decodable>(for decoder: JSONDecoder) -> (Data) -> Result<T, AnyError> {
+    public static func dataTransformer<T: Decodable, E: DecodingFailureInitializable>(for decoder: JSONDecoder) -> (Data) -> Result<T, E> {
         return { data in
             do {
                 let decodedResponse: T = try decoder.decode(T.self, from: data)
                 return .success(decodedResponse)
             } catch {
-                return .failure(AnyError(error))
+                guard let decodingError = error as? DecodingError else { fatalError("JSONDecoder should alsays throw a DecodingError.") }
+                return .failure(E(decodingError: decodingError, data: data))
             }
         }
     }
 }
+
+// MARK: - NetworkRequest Default Implementations
 
 public extension NetworkRequest {
     
@@ -153,7 +166,7 @@ public extension NetworkRequest {
     }
 }
 
-public extension NetworkRequest where ResponseType: Decodable, ErrorType == AnyError {
+public extension NetworkRequest where ResponseType: Decodable, ErrorType: DecodingFailureInitializable {
     
     func dataTransformer(with decoder: JSONDecoder) -> (Data) -> Result<ResponseType, ErrorType> {
         return NetworkRequestDefaults.dataTransformer(for: decoder)
@@ -167,5 +180,21 @@ public extension NetworkRequest where ResponseType: Decodable, ErrorType == AnyE
 public extension NetworkRequest where ResponseType == EmptyResponse {
     func transformData(_ data: Data) -> Result<EmptyResponse, ErrorType> {
         return .success(EmptyResponse())
+    }
+}
+
+// MARK: - AnyError Conformance to NetworkServiceInitializable
+
+extension AnyError: NetworkServiceFailureInitializable {
+    public init(networkServiceFailure: NetworkServiceFailure) {
+        self.init(networkServiceFailure.error)
+    }
+}
+
+// MARK: - AnyError Conformance to NetworkServiceInitializable
+
+extension AnyError: DecodingFailureInitializable {
+    public init(decodingError: DecodingError, data: Data) {
+        self.init(decodingError)
     }
 }

--- a/Sources/Hyperspace/Service/Backend/BackendService.swift
+++ b/Sources/Hyperspace/Service/Backend/BackendService.swift
@@ -29,14 +29,14 @@ public class BackendService {
 // MARK: - BackendService Conformance to BackendServiceProtocol
 
 extension BackendService: BackendServiceProtocol {
-    public func execute<T: NetworkRequest>(request: T, completion: @escaping BackendServiceCompletion<T.ResponseType>) {
-        networkService.execute(request: request.urlRequest) { (result) in
+    public func execute<T: NetworkRequest>(request: T, completion: @escaping BackendServiceCompletion<T.ResponseType, T.ErrorType>) {
+        networkService.execute(request: request.urlRequest) { result in
             switch result {
             case .success(let result):
                 BackendServiceHelper.handleResponseData(result.data, for: request, completion: completion)
             case .failure(let result):
                 DispatchQueue.main.async {
-                    completion(.failure(.networkError(result.error, result.response)))
+                    completion(.failure(T.ErrorType(networkServiceFailure: result)))
                 }
             }
         }

--- a/Sources/Hyperspace/Service/Backend/BackendServiceHelper.swift
+++ b/Sources/Hyperspace/Service/Backend/BackendServiceHelper.swift
@@ -17,7 +17,7 @@ public struct BackendServiceHelper {
     ///   - data: The raw Data retrieved from the network.
     ///   - request: The NetworkRequest that will be used to transform the Data.
     ///   - completion: The completion block to invoke when execution has finished.
-    public static func handleResponseData<T: NetworkRequest>(_ data: Data, for request: T, completion: @escaping BackendServiceCompletion<T.ResponseType>) {
+    public static func handleResponseData<T: NetworkRequest>(_ data: Data, for request: T, completion: @escaping BackendServiceCompletion<T.ResponseType, T.ErrorType>) {
         let transformResult = request.transformData(data)
         
         DispatchQueue.main.async {
@@ -25,7 +25,7 @@ public struct BackendServiceHelper {
             case .success(let transformedObject):
                 completion(.success(transformedObject))
             case .failure(let error):
-                completion(.failure(.dataTransformationError(error)))
+                completion(.failure(error))
             }
         }
     }

--- a/Sources/Hyperspace/Service/Backend/BackendServiceProtocol.swift
+++ b/Sources/Hyperspace/Service/Backend/BackendServiceProtocol.swift
@@ -9,29 +9,10 @@
 import Foundation
 import Result
 
-/// Represents an error that a BackendService can produce.
-///
-/// - networkError: Represents an error that ocurred with the underlying NetworkService.
-/// - dataTransformationError: Represents an error that ocurred when parsing the raw Data into the associated model type.
-public enum BackendServiceError: Error {
-    case networkError(NetworkServiceError, HTTP.Response?)
-    case dataTransformationError(Error)
-}
-
-/// Represents an error that can be created from a BackendServiceError. This type can be used for strongly typed error handling.
-public protocol BackendServiceErrorInitializable: Error {
-    init(_ backendServiceError: BackendServiceError)
-}
-
-/// Represents the completion of a request executed using a BackendService.
-/// When successful, the parsed object is provided as the associated value.
-/// When request execution fails, the relevant BackendServiceError is provided as the associated value.
-public typealias BackendServiceCompletion<T> = (Result<T, BackendServiceError>) -> Void
-
 /// Represents the completion of a request executed using a BackendService.
 /// When successful, the parsed object is provided as the associated value.
 /// When request execution fails, the relevant E is provided as the associated value.
-public typealias TypedBackendServiceCompletion<T, E: Swift.Error> = (Result<T, E>) -> Void
+public typealias BackendServiceCompletion<T, E: Swift.Error> = (Result<T, E>) -> Void
 
 /// Represents something that's capable of executing a typed NetworkRequest
 public protocol BackendServiceProtocol {
@@ -41,52 +22,11 @@ public protocol BackendServiceProtocol {
     /// - Parameters:
     ///   - request: The NetworkRequest to be executed.
     ///   - completion: The completion block to invoke when execution has finished.
-    func execute<T: NetworkRequest>(request: T, completion: @escaping BackendServiceCompletion<T.ResponseType>)
-    
-    /// Executes the NetworkRequest, calling the provided typed error completion block when finished.
-    ///
-    /// - Parameters:
-    ///   - request: The NetworkRequest to be executed.
-    ///   - completion: The completion block (with a specifcally typed error) to invoke when execution has finished.
-    func execute<T: NetworkRequest, E: BackendServiceErrorInitializable>(request: T, completion: @escaping TypedBackendServiceCompletion<T.ResponseType, E>) where T.ErrorType == E
+    func execute<T: NetworkRequest>(request: T, completion: @escaping BackendServiceCompletion<T.ResponseType, T.ErrorType>)
     
     /// Cancels the task for the given request (if it is currently running).
     func cancelTask(for request: URLRequest)
     
     /// Cancels all currently running tasks
     func cancelAllTasks()
-}
-
-// MARK: - Default Typed Implementation
-
-extension BackendServiceProtocol {
-    public func execute<T: NetworkRequest, E: BackendServiceErrorInitializable>(request: T, completion: @escaping TypedBackendServiceCompletion<T.ResponseType, E>) where T.ErrorType == E {
-        execute(request: request) { (result: Result<T.ResponseType, BackendServiceError>) in
-            completion(result.flatMapError { .failure(E($0)) })
-        }
-    }
-}
-
-// MARK: - Equatable Implementations
-
-extension BackendServiceError: Equatable {
-    public static func == (lhs: BackendServiceError, rhs: BackendServiceError) -> Bool {
-        switch (lhs, rhs) {
-        case (.networkError(let lhsError, let lhsResponse), .networkError(let rhsError, let rhsResponse)):
-            return lhsError == rhsError && lhsResponse == rhsResponse
-        case (.dataTransformationError(let lhsError), .dataTransformationError(let rhsError)):
-            // TODO: Need to come up with a better way to compare equality in this case
-            return lhsError.localizedDescription == rhsError.localizedDescription
-        default:
-            return false
-        }
-    }
-}
-
-// MARK: - AnyError Conformance to BackendServiceErrorInitializable
-
-extension AnyError: BackendServiceErrorInitializable {
-    public init(_ backendServiceError: BackendServiceError) {
-        self.init(backendServiceError as Error)
-    }
 }

--- a/Sources/Hyperspace/Service/Network/NetworkServiceProtocol.swift
+++ b/Sources/Hyperspace/Service/Network/NetworkServiceProtocol.swift
@@ -8,7 +8,6 @@
 
 //
 //  TODO: Future functionality:
-//          - Look into providing a protocol that allows clients to custom interpret URLResponses (HTTP status codes).
 //          - Look into providing the raw URLResponse as a property on NetworkServiceSuccess/FailureResult so that clients have access to the raw response object.
 //            One caveat is the fact that HTTPURLResponse and URLResponse don't currently properly handle Equatable so we'll need to figure out how we want to handle this.
 //

--- a/Tests/BackendServiceTests.swift
+++ b/Tests/BackendServiceTests.swift
@@ -26,6 +26,14 @@ class BackendServiceTests: XCTestCase {
     
     // MARK: - Tests
     
+    func test_AnyError_CreatesSuccessfullyFromNetworkServiceFailure() {
+        let failure = NetworkServiceFailure(error: .noInternetConnection, response: nil)
+        let anyError = AnyError(networkServiceFailure: failure)
+        
+        XCTAssertTrue(anyError.error is NetworkServiceError)
+        XCTAssertEqual(anyError.error as! NetworkServiceError, .noInternetConnection)
+    }
+    
     func test_NetworkServiceSuccess_TransformsResponseCorrectly() {
         let model = NetworkRequestTestDefaults.defaultModel
         let mockedResult = NetworkServiceSuccess(data: modelJSONData, response: defaultSuccessResponse)

--- a/Tests/BackendServiceTests.swift
+++ b/Tests/BackendServiceTests.swift
@@ -82,21 +82,12 @@ class BackendServiceTests: XCTestCase {
         XCTAssertEqual(mockNetworkService.cancelAllTasksCallCount, 1)
     }
     
-    func test_AnyErrorBackendServiceErrorInitializableConformance_CreatesAnyErrorWithBackendServiceError() {
-        let error = AnyError(BackendServiceError.networkError(.unknownError, nil))
-        XCTAssert(error.error is BackendServiceError)
-    }
-    
-    func test_BackendServiceErrorEquatableConformance_DifferentErrorsAreNotEqual() {
-        let lhs = BackendServiceError.networkError(.unknownError, nil)
-        let rhs = BackendServiceError.dataTransformationError(NSError(domain: "Test", code: 1, userInfo: nil))
-        XCTAssertNotEqual(lhs, rhs)
-    }
-    
     // MARK: - Private
     
+    //create a concrete implementation of NetworkServiceFailureInitializable(Error) for testing (aka BackendServiceError...)
+    
     private func executeBackendService(mockedNetworkServiceResult: Result<NetworkServiceSuccess, NetworkServiceFailure>,
-                                       expectingResult expectedResult: Result<DefaultModel, BackendServiceError>,
+                                       expectingResult expectedResult: Result<DefaultModel, MockBackendServiceError>,
                                        file: StaticString = #file,
                                        line: UInt = #line) {
         let mockNetworkService = MockNetworkService(responseResult: mockedNetworkServiceResult)

--- a/Tests/Helper/Mocks/MockBackendService.swift
+++ b/Tests/Helper/Mocks/MockBackendService.swift
@@ -7,8 +7,35 @@
 //
 
 import Foundation
-import Hyperspace
+@testable import Hyperspace
 import Result
+
+public enum MockBackendServiceError: NetworkServiceFailureInitializable, DecodingFailureInitializable {
+    case networkError(NetworkServiceError, HTTP.Response?)
+    case dataTransformationError(Error)
+    
+    public init(networkServiceFailure: NetworkServiceFailure) {
+        self = .networkError(networkServiceFailure.error, networkServiceFailure.response)
+    }
+    
+    public init(decodingError: DecodingError, data: Data) {
+        self = .dataTransformationError(decodingError)
+    }
+}
+
+extension MockBackendServiceError: Equatable {
+    public static func == (lhs: MockBackendServiceError, rhs: MockBackendServiceError) -> Bool {
+        switch (lhs, rhs) {
+        case (.networkError(let lhsError, let lhsResponse), .networkError(let rhsError, let rhsResponse)):
+            return lhsError == rhsError && lhsResponse == rhsResponse
+        case (.dataTransformationError(let lhsError), .dataTransformationError(let rhsError)):
+            // TODO: Need to come up with a better way to compare equality in this case
+            return lhsError.localizedDescription == rhsError.localizedDescription
+        default:
+            return false
+        }
+    }
+}
 
 struct MockBackendService: BackendServiceProtocol {
     func cancelTask(for request: URLRequest) {
@@ -19,7 +46,8 @@ struct MockBackendService: BackendServiceProtocol {
         /* No op */
     }
     
-    func execute<T>(request: T, completion: @escaping (Result<T.ResponseType, BackendServiceError>) -> Void) where T: NetworkRequest {
-        completion( Result.failure(BackendServiceError.networkError(NetworkServiceError.timedOut, nil)))
+    func execute<T>(request: T, completion: @escaping (Result<T.ResponseType, T.ErrorType>) -> Void) where T: NetworkRequest {
+        let failure = NetworkServiceFailure(error: .timedOut, response: nil)
+        completion(Result.failure(T.ErrorType(networkServiceFailure: failure)))
     }
 }

--- a/Tests/Helper/Test Defaults/NetworkRequestTestDefaults.swift
+++ b/Tests/Helper/Test Defaults/NetworkRequestTestDefaults.swift
@@ -16,9 +16,10 @@ class NetworkRequestTestDefaults {
     }
     
     struct DefaultRequest<T: Decodable>: NetworkRequest {
+        
         // swiftlint:disable nesting
         typealias ResponseType = T
-        typealias ErrorType = AnyError
+        typealias ErrorType = MockBackendServiceError
         // swiftlint:enable nesting
         
         var method: HTTP.Method = .get


### PR DESCRIPTION
This should help address #28 .

Changes made:

- Created a new protocol, `NetworkServiceFailureInitializable` (not sold on the name). This is any error that can be initialized from a `NetworkServiceFailure` as so: ` init(networkServiceFailure:)`
- Created a new protocol, `DecodingFailureInitializable` (not sold on the name). This is any error that can be initialized from a failed Codable decode as so: `init(decodingError:data:)`.
- Removed `BackendServiceError`. It is now only implemented in tests.
- Created another associated type for `NetworkRequest`, `ErrorType`, which must be `NetworkServiceFailureInitializable`. `AnyError has been expanded to conform to this protocol, so `AnyNetworkRequest<T>` is unchanged (but lots of code has been deleted, so yay).

This combination of changes allows for a few improvements:
- If the `NetworkService` creates any sort of failure response, instead of getting a generic `BackendServiceError`, `NetworkRequest.ErrorType.init` is called with the reason for the failure. This should give easy access to the `Data` in the failure (and any other part of it).
- If the `NetworkRequest.ResponseType` conforms to `Codable` and fails to decode, `NetworkRequest.ErrorType.init` can be called with both the failure and the data attempting to be decoded. There is an extension to apply a default for when `NetworkRequest.ErrorType` conforms to `DecodingFailureInitializable`.

Oh, and it changes the interface significantly enough that, if approved, we'll want to roll it up with some of the other proposed v2 changes.