### PR TITLE
RFC: Separate URL Query configuration from NetworkRequest

### DIFF
--- a/Examples/Playground/Hyperspace.playground/Contents.swift
+++ b/Examples/Playground/Hyperspace.playground/Contents.swift
@@ -48,7 +48,6 @@ struct GetUserRequest: NetworkRequest {
     var url: URL {
         return URL(string: "http://jsonplaceholder.typicode.com/users/\(userId)")!
     }
-    var queryParameters: [URLQueryItem]?
     var headers: [HTTP.HeaderKey: HTTP.HeaderValue]?
     var body: Data?
     
@@ -69,7 +68,6 @@ struct CreatePostRequest: NetworkRequest {
     // Define NetworkRequest property values
     var method: HTTP.Method = .post
     var url = URL(string: "http://jsonplaceholder.typicode.com/posts")!
-    var queryParameters: [URLQueryItem]?
     var headers: [HTTP.HeaderKey: HTTP.HeaderValue]? = [.contentType: .applicationJSON]
     var body: Data? {
         let encoder = JSONEncoder()

--- a/Examples/Playground/Hyperspace_DELETE.playground/Contents.swift
+++ b/Examples/Playground/Hyperspace_DELETE.playground/Contents.swift
@@ -15,7 +15,6 @@ struct DeletePostRequest: NetworkRequest {
     var url: URL {
         return URL(string: "http://jsonplaceholder.typicode.com/posts/\(postId)")!
     }
-    var queryParameters: [URLQueryItem]?
     var headers: [HTTP.HeaderKey: HTTP.HeaderValue]?
     var body: Data?
 

--- a/Examples/Shared/NetworkRequests.swift
+++ b/Examples/Shared/NetworkRequests.swift
@@ -44,7 +44,6 @@ struct GetUserRequest: NetworkRequest {
     var url: URL {
         return URL(string: "https://jsonplaceholder.typicode.com/users/\(userId)")!
     }
-    var queryParameters: [URLQueryItem]?
     var headers: [HTTP.HeaderKey: HTTP.HeaderValue]?
     var body: Data?
     
@@ -67,7 +66,6 @@ struct CreatePostRequest: NetworkRequest {
     // Define NetworkRequest property values
     var method: HTTP.Method = .post
     var url = URL(string: "https://jsonplaceholder.typicode.com/posts")!
-    var queryParameters: [URLQueryItem]?
     var headers: [HTTP.HeaderKey: HTTP.HeaderValue]? = [.contentType: .applicationJSON]
     var body: Data? {
         let encoder = JSONEncoder()
@@ -93,7 +91,6 @@ struct DeletePostRequest: NetworkRequest {
     var url: URL {
         return URL(string: "https://jsonplaceholder.typicode.com/posts/\(postId)")!
     }
-    var queryParameters: [URLQueryItem]?
     var headers: [HTTP.HeaderKey: HTTP.HeaderValue]?
     var body: Data?
     

--- a/Hyperspace.xcodeproj/project.pbxproj
+++ b/Hyperspace.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0ECDC1C420A9EDA500ABF991 /* URLQueryParameterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ECDC1C220A9ED6700ABF991 /* URLQueryParameterTests.swift */; };
+		0ECDC1C520A9EDA600ABF991 /* URLQueryParameterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ECDC1C220A9ED6700ABF991 /* URLQueryParameterTests.swift */; };
 		3026E459202008720003A321 /* NetworkSessionTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3026E457202008470003A321 /* NetworkSessionTest.swift */; };
 		3026E45A2020087C0003A321 /* NetworkSessionTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3026E457202008470003A321 /* NetworkSessionTest.swift */; };
 		30F0735420210A890045CB01 /* HTTPTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30F07352202109F60045CB01 /* HTTPTests.swift */; };
@@ -260,6 +262,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0ECDC1C220A9ED6700ABF991 /* URLQueryParameterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLQueryParameterTests.swift; sourceTree = "<group>"; };
 		3026E457202008470003A321 /* NetworkSessionTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkSessionTest.swift; sourceTree = "<group>"; };
 		30F07352202109F60045CB01 /* HTTPTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPTests.swift; sourceTree = "<group>"; };
 		30F073562021720B0045CB01 /* MockBackendService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockBackendService.swift; sourceTree = "<group>"; };
@@ -505,6 +508,7 @@
 				3026E457202008470003A321 /* NetworkSessionTest.swift */,
 				30F07352202109F60045CB01 /* HTTPTests.swift */,
 				B4C32C32201E9F9300FC82C1 /* NetworkActivityIndicatorTests.swift */,
+				0ECDC1C220A9ED6700ABF991 /* URLQueryParameterTests.swift */,
 				60D6C419201CFCE500B3B012 /* Helper */,
 				60EB8FDA1FF59FB000AC0B55 /* Supporting Files */,
 			);
@@ -1137,6 +1141,7 @@
 				60D6C409201CFCCF00B3B012 /* MockNetworkService.swift in Sources */,
 				60D6C403201CFCCF00B3B012 /* DecodingTests.swift in Sources */,
 				30F07361202213E50045CB01 /* NetworkRequestTestDefaults.swift in Sources */,
+				0ECDC1C420A9EDA500ABF991 /* URLQueryParameterTests.swift in Sources */,
 				60D6C40D201CFCCF00B3B012 /* NetworkRequestTests.swift in Sources */,
 				30F0735420210A890045CB01 /* HTTPTests.swift in Sources */,
 				3026E459202008720003A321 /* NetworkSessionTest.swift in Sources */,
@@ -1203,6 +1208,7 @@
 				60D6C40A201CFCCF00B3B012 /* MockNetworkService.swift in Sources */,
 				60D6C404201CFCCF00B3B012 /* DecodingTests.swift in Sources */,
 				30F07362202213E60045CB01 /* NetworkRequestTestDefaults.swift in Sources */,
+				0ECDC1C520A9EDA600ABF991 /* URLQueryParameterTests.swift in Sources */,
 				60D6C40E201CFCCF00B3B012 /* NetworkRequestTests.swift in Sources */,
 				30F0735520210A8B0045CB01 /* HTTPTests.swift in Sources */,
 				3026E45A2020087C0003A321 /* NetworkSessionTest.swift in Sources */,

--- a/Sources/Hyperspace/Extensions/URL+Additions.swift
+++ b/Sources/Hyperspace/Extensions/URL+Additions.swift
@@ -9,11 +9,46 @@
 import Foundation
 
 extension URL {
+    
     func appendingQueryString(_ queryString: String) -> URL {
         // Conditionally add the '?' character
         let fullQueryString = queryString.isEmpty ? "" : "?\(queryString)"
         
         guard let url = URL(string: "\(absoluteString)\(fullQueryString)") else { fatalError("Unable to create \(URL.self) from query string: \(fullQueryString)") }
         return url
+    }
+}
+
+public extension URL {
+    
+    /// Represents the strategy used to encode query parameters in the URL.
+    // swiftlint:disable nesting
+    public enum QueryParameterEncodingStrategy {
+        public typealias QueryStringEncodingBlock = (String) -> String
+        
+        case urlQueryAllowedCharacterSet
+        case custom(QueryStringEncodingBlock)
+        
+        func encode(string: String) -> String {
+            switch self {
+            case .urlQueryAllowedCharacterSet:
+                guard let encodedQueryString = string.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) else { fatalError("Unable to encode query parameters for \(self)") }
+                return encodedQueryString
+            case .custom(let encodingBlock):
+                return encodingBlock(string)
+            }
+        }
+    }
+    // swiftlint:enable nesting
+    
+    /// Encodes and appends an array of query items to a URL, returning a new URL with the query appended.
+    ///
+    /// - Parameters:
+    ///   - items: An array of `URLQueryItem` to be encoded into the URL query string.
+    ///   - encodingStrategy: The appropriate type of `URL.QueryParameterEncodingStrategy` to be used for encoding.
+    /// - Returns: Returns the resulting URL after query encoding and addition.
+    func appendingQueryItems(_ items: [URLQueryItem], using encodingStrategy: QueryParameterEncodingStrategy = .urlQueryAllowedCharacterSet) -> URL {
+        let queryString = URLQueryItem.generateRawQueryParametersString(from: items)
+        return appendingQueryString(encodingStrategy.encode(string: queryString))
     }
 }

--- a/Sources/Hyperspace/Request/AnyNetworkRequest.swift
+++ b/Sources/Hyperspace/Request/AnyNetworkRequest.swift
@@ -16,45 +16,32 @@ public struct AnyNetworkRequest<T>: NetworkRequest {
     
     public var method: HTTP.Method
     public var url: URL
-    public var queryParameters: [URLQueryItem]?
-    public var queryParameterEncodingStrategy: NetworkRequestQueryParameterEncodingStrategy
     public var headers: [HTTP.HeaderKey: HTTP.HeaderValue]?
     public var body: Data?
     public var cachePolicy: URLRequest.CachePolicy
     public var timeout: TimeInterval
-    private let _generateRawQueryParameterString: ([URLQueryItem]) -> String
     private let _transformData: (Data) -> Result<T, AnyError>
     
     // MARK: - Init
     
     public init(method: HTTP.Method,
                 url: URL,
-                queryParameters: [URLQueryItem]? = nil,
-                queryParameterEncodingStrategy: NetworkRequestQueryParameterEncodingStrategy = NetworkRequestDefaults.defaultQueryParameterEncodingStrategy,
                 headers: [HTTP.HeaderKey: HTTP.HeaderValue]? = nil,
                 body: Data? = nil,
                 cachePolicy: URLRequest.CachePolicy = NetworkRequestDefaults.defaultCachePolicy,
                 timeout: TimeInterval = NetworkRequestDefaults.defaultTimeout,
-                rawQueryParameterStringTransformBlock: @escaping ([URLQueryItem]) -> String = URLQueryItem.generateRawQueryParametersString,
                 dataTransformationBlock: @escaping (Data) -> Result<T, AnyError>) {
         self.method = method
         self.url = url
-        self.queryParameters = queryParameters
-        self.queryParameterEncodingStrategy = queryParameterEncodingStrategy
         self.headers = headers
         self.body = body
         self.cachePolicy = cachePolicy
         self.timeout = timeout
         
-        _generateRawQueryParameterString = rawQueryParameterStringTransformBlock
         _transformData = dataTransformationBlock
     }
     
     // MARK: - Public
-    
-    public func generateRawQueryParameterString(from queryParameters: [URLQueryItem]) -> String {
-        return _generateRawQueryParameterString(queryParameters)
-    }
     
     public func transformData(_ data: Data) -> Result<T, AnyError> {
         return _transformData(data)
@@ -65,24 +52,18 @@ extension AnyNetworkRequest where T: Decodable {
     
     public init(method: HTTP.Method,
                 url: URL,
-                queryParameters: [URLQueryItem]? = nil,
-                queryParameterEncodingStrategy: NetworkRequestQueryParameterEncodingStrategy = NetworkRequestDefaults.defaultQueryParameterEncodingStrategy,
                 headers: [HTTP.HeaderKey: HTTP.HeaderValue]? = nil,
                 body: Data? = nil,
                 cachePolicy: URLRequest.CachePolicy = NetworkRequestDefaults.defaultCachePolicy,
                 timeout: TimeInterval = NetworkRequestDefaults.defaultTimeout,
-                rawQueryParameterStringTransformBlock: @escaping ([URLQueryItem]) -> String = URLQueryItem.generateRawQueryParametersString,
                 decoder: JSONDecoder = JSONDecoder()) {
         self.method = method
         self.url = url
-        self.queryParameters = queryParameters
-        self.queryParameterEncodingStrategy = queryParameterEncodingStrategy
         self.headers = headers
         self.body = body
         self.cachePolicy = cachePolicy
         self.timeout = timeout
         
-        _generateRawQueryParameterString = rawQueryParameterStringTransformBlock
         _transformData = NetworkRequestDefaults.dataTransformer(for: decoder)
     }
 }

--- a/Tests/Helper/Test Defaults/NetworkRequestTestDefaults.swift
+++ b/Tests/Helper/Test Defaults/NetworkRequestTestDefaults.swift
@@ -23,7 +23,6 @@ class NetworkRequestTestDefaults {
         
         var method: HTTP.Method = .get
         var url: URL = NetworkRequestTestDefaults.defaultURL
-        var queryParameters: [URLQueryItem]?
         var headers: [HTTP.HeaderKey: HTTP.HeaderValue]?
         var body: Data?
         var cachePolicy: URLRequest.CachePolicy = NetworkRequestTestDefaults.defaultCachePolicy

--- a/Tests/NetworkRequestTests.swift
+++ b/Tests/NetworkRequestTests.swift
@@ -29,7 +29,6 @@ class NetworkRequestTests: XCTestCase {
         
         var method: HTTP.Method = NetworkRequestTests.defaultRequestMethod
         var url = NetworkRequestTests.defaultURL
-        var queryParameters: [URLQueryItem]?
         var headers: [HTTP.HeaderKey: HTTP.HeaderValue]?
         var body: Data?
         var cachePolicy: URLRequest.CachePolicy = NetworkRequestTests.defaultCachePolicy
@@ -44,7 +43,6 @@ class NetworkRequestTests: XCTestCase {
         
         var method: HTTP.Method = .post
         var url = NetworkRequestTests.defaultURL
-        var queryParameters: [URLQueryItem]?
         var headers: [HTTP.HeaderKey: HTTP.HeaderValue]?
         var body: Data?
         var cachePolicy: URLRequest.CachePolicy = NetworkRequestTests.defaultCachePolicy
@@ -59,46 +57,15 @@ class NetworkRequestTests: XCTestCase {
         
         var method: HTTP.Method = NetworkRequestTests.defaultRequestMethod
         var url = NetworkRequestTests.defaultURL
-        var queryParameters: [URLQueryItem]?
         var headers: [HTTP.HeaderKey: HTTP.HeaderValue]?
         var body: Data?
-    }
-    
-    struct CustomQueryEncodingRequest: NetworkRequest {
-        // swiftlint:disable nesting
-        typealias ResponseType = EmptyResponse
-        typealias ErrorType = AnyError
-        // swiftlint:enable nesting
-        
-        var method: HTTP.Method = NetworkRequestTests.defaultRequestMethod
-        var url = NetworkRequestTests.defaultURL
-        var queryParameters: [URLQueryItem]?
-        var headers: [HTTP.HeaderKey: HTTP.HeaderValue]?
-        var body: Data?
-        var queryParameterEncodingStrategy =  NetworkRequestQueryParameterEncodingStrategy.custom { (content) -> String in
-            return content.replacingOccurrences(of: " ", with: "-", options: NSString.CompareOptions.literal, range: nil)
-        }
     }
     
     // MARK: - Tests
     
     func test_SimpleGETRequestWithoutQueryParametersOrHeaders_GeneratesCorrectURLRequest() {
         let request = SimpleGETRequest()
-        
         assertParameters(for: request)
-    }
-    
-    func test_SimpleGETRequestWithQueryParameters_GeneratesCorrectURLRequest() {
-        var request = SimpleGETRequest()
-        
-        request.queryParameters = [
-            URLQueryItem(name: "param1", value: "param1value"),
-            URLQueryItem(name: "param2", value: "param2 value"),
-            URLQueryItem(name: "param3", value: nil)
-            // TODO: What other complex query parameters can we generate to test the URL encoding?
-        ]
-        
-        assertParameters(urlString: "http://apple.com?param1=param1value&param2=param2%20value&param3", for: request)
     }
     
     func test_SimpleGETRequestWithHeaders_GeneratesCorrectURLRequest() {
@@ -127,27 +94,13 @@ class NetworkRequestTests: XCTestCase {
         XCTAssert(request.cachePolicy == .useProtocolCachePolicy)
         XCTAssert(request.timeout == 30)
     }
-    
-    func test_NetworkRequest_EncodeQueryParameterString() {
-        let request = CachePolicyAndTimeOutRequest()
-        let queryString = request.encodeQueryParameterString("this is a test")
         
-        XCTAssert(queryString == "this%20is%20a%20test")
-    }
-    
     func test_NetworkRequest_TransformData() {
         
         let request = CachePolicyAndTimeOutRequest()
         let result: Result<CachePolicyAndTimeOutRequest.ResponseType, CachePolicyAndTimeOutRequest.ErrorType> = request.transformData("this is dummy content".data(using: .utf8)!)
         
         XCTAssertNotNil(result.value)
-    }
-    
-    func test_NetworkRequest_CustomQueryEncoding() {
-        let request = CustomQueryEncodingRequest()
-        let queryString = request.encodeQueryParameterString("this is a test")
-        
-        XCTAssert(queryString == "this-is-a-test")
     }
     
     // MARK: - Private

--- a/Tests/URLQueryParameterTests.swift
+++ b/Tests/URLQueryParameterTests.swift
@@ -1,0 +1,55 @@
+//
+//  URLQueryParameterTests.swift
+//  Hyperspace-iOS
+//
+//  Created by Will McGinty on 5/14/18.
+//  Copyright © 2018 Bottle Rocket Studios. All rights reserved.
+//
+
+import XCTest
+@testable import Hyperspace
+
+class URLQueryParameterTests: XCTestCase {
+    
+    func test_DefaultURLQueryEncodingStraegy_GeneratesCorrectURL() {
+        let url = NetworkRequestTestDefaults.defaultURL
+        
+        let queryParameters = [
+            URLQueryItem(name: "param1", value: "param1value"),
+            URLQueryItem(name: "param2", value: "param2 value"),
+            URLQueryItem(name: "param3", value: nil)
+            // TODO: What other complex query parameters can we generate to test the URL encoding?
+        ]
+        
+        let finalURL = url.appendingQueryItems(queryParameters, using: .urlQueryAllowedCharacterSet)
+        XCTAssertEqual(finalURL.absoluteString, "https://apple.com?param1=param1value&param2=param2%20value&param3")
+    }
+    
+    func testCustomURLQueryEncodingStrategy_GeneratesCorrectURL() {
+        let queryParameters = [
+            URLQueryItem(name: "param1", value: "param1value"),
+            URLQueryItem(name: "param2", value: "param2 value"),
+            URLQueryItem(name: "param3", value: nil)
+        ]
+        
+        let url = NetworkRequestTestDefaults.defaultURL
+        let finalURL = url.appendingQueryItems(queryParameters, using: .customTest)
+        XCTAssertEqual(finalURL.absoluteString, "https://apple.com?param1=param1value&param2=param2-value&param3")
+    }
+    
+    func testDefaultURLQueryEncodingStrategy_EncodesQueryProperly() {
+        let queryString = URL.QueryParameterEncodingStrategy.urlQueryAllowedCharacterSet.encode(string: "this is a test")
+        XCTAssertEqual(queryString, "this%20is%20a%20test")
+    }
+    
+    func testCustomURLQueryEncodingStrategy_EncodesQueryProperly() {
+        let queryString = URL.QueryParameterEncodingStrategy.customTest.encode(string: "this is a test")
+        XCTAssertEqual(queryString, "this-is-a-test")
+    }
+}
+
+fileprivate extension URL.QueryParameterEncodingStrategy {
+    static let customTest = URL.QueryParameterEncodingStrategy.custom { content in
+        return content.replacingOccurrences(of: " ", with: "-", options: .literal, range: nil)
+    }
+}


### PR DESCRIPTION
This is an initial implementation of #37. It moves the encoding and appending of the URL query into a category on URL (maintaining the encoding strategies).

Thoughts?