### PR TITLE
RFC: Runtime Root Key Decoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 * Two new error-facing protocols were added. `NetworkServiceFailureInitializable` represents a `Swift.Error` that can be initialized from a `NetworkServiceFailure` object. `DecodingFailureInitializable` represents a `Swift.Error` that can be initialized from a `DecodingError` as a result of decoding `Data`. These conformances have been added as extensions to `AnyError` (meaning `AnyNetworkRequest` usage is unaffected). As a result of these new protocols, the `BackendServiceError` type has been removed. Types conforming to `NetworkRequest` now have an associated `ErrorType` which must conform to `NetworkServiceFailureInitializable`. If a request generates any sort of failure response, the custom error type will be initialized from it instead of returning a generic `BackendServiceError`. In addition, if `NetworkRequest.ErrorType` conforms to `DecodingFailureInitializable`, the custom erorr type will be instantiated and returned.
     [Will McGinty](https://github.com/wmcginty)
     [#38](https://github.com/BottleRocketStudios/iOS-Hyperspace/pull/38)
+    
+* Added a new initalizer to `AnyNetworkRequest` which accepts a `String` value designating the key of JSON at which to begin decoding.
+    [Will McGinty](https://github.com/wmcginty)
+    [#41](https://github.com/BottleRocketStudios/iOS-Hyperspace/pull/41)
 
 ##### Bug Fixes
 

--- a/Hyperspace.xcodeproj/project.pbxproj
+++ b/Hyperspace.xcodeproj/project.pbxproj
@@ -7,6 +7,11 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0ECDC1C820A9FBE600ABF991 /* RootKeyObjectPlus.json in Resources */ = {isa = PBXBuildFile; fileRef = 0ECDC1C620A9FB8300ABF991 /* RootKeyObjectPlus.json */; };
+		0ECDC1C920A9FBE600ABF991 /* RootKeyObjectPlus.json in Resources */ = {isa = PBXBuildFile; fileRef = 0ECDC1C620A9FB8300ABF991 /* RootKeyObjectPlus.json */; };
+		0ECDC1CC20A9FD3500ABF991 /* RootKeyIncorrectType.json in Resources */ = {isa = PBXBuildFile; fileRef = 0ECDC1CA20A9FCDE00ABF991 /* RootKeyIncorrectType.json */; };
+		0ECDC1CD20A9FD3600ABF991 /* RootKeyIncorrectType.json in Resources */ = {isa = PBXBuildFile; fileRef = 0ECDC1CA20A9FCDE00ABF991 /* RootKeyIncorrectType.json */; };
+		0ECDC1CF20A9FE3100ABF991 /* AnyDecodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ECDC1CE20A9FE3100ABF991 /* AnyDecodable.swift */; };
 		3026E459202008720003A321 /* NetworkSessionTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3026E457202008470003A321 /* NetworkSessionTest.swift */; };
 		3026E45A2020087C0003A321 /* NetworkSessionTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3026E457202008470003A321 /* NetworkSessionTest.swift */; };
 		30F0735420210A890045CB01 /* HTTPTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30F07352202109F60045CB01 /* HTTPTests.swift */; };
@@ -260,6 +265,9 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0ECDC1C620A9FB8300ABF991 /* RootKeyObjectPlus.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = RootKeyObjectPlus.json; sourceTree = "<group>"; };
+		0ECDC1CA20A9FCDE00ABF991 /* RootKeyIncorrectType.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = RootKeyIncorrectType.json; sourceTree = "<group>"; };
+		0ECDC1CE20A9FE3100ABF991 /* AnyDecodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyDecodable.swift; sourceTree = "<group>"; };
 		3026E457202008470003A321 /* NetworkSessionTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkSessionTest.swift; sourceTree = "<group>"; };
 		30F07352202109F60045CB01 /* HTTPTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPTests.swift; sourceTree = "<group>"; };
 		30F073562021720B0045CB01 /* MockBackendService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockBackendService.swift; sourceTree = "<group>"; };
@@ -542,6 +550,7 @@
 		60AC83431FF596B600120172 /* Request */ = {
 			isa = PBXGroup;
 			children = (
+				0ECDC1CE20A9FE3100ABF991 /* AnyDecodable.swift */,
 				60AC83441FF596B600120172 /* AnyNetworkRequest+DecodableContainer.swift */,
 				60AC83451FF596B600120172 /* AnyNetworkRequest.swift */,
 				60AC83461FF596B600120172 /* NetworkRequest.swift */,
@@ -610,6 +619,8 @@
 			children = (
 				60D6C3F9201CFCCF00B3B012 /* DateObject.json */,
 				60D6C3FA201CFCCF00B3B012 /* RootKeyObject.json */,
+				0ECDC1C620A9FB8300ABF991 /* RootKeyObjectPlus.json */,
+				0ECDC1CA20A9FCDE00ABF991 /* RootKeyIncorrectType.json */,
 				60D6C3FB201CFCCF00B3B012 /* Object.json */,
 				60D6C3FC201CFCCF00B3B012 /* RootKeyArray.json */,
 			);
@@ -998,9 +1009,11 @@
 			buildActionMask = 2147483647;
 			files = (
 				60D6C413201CFCCF00B3B012 /* Object.json in Resources */,
+				0ECDC1C820A9FBE600ABF991 /* RootKeyObjectPlus.json in Resources */,
 				60D6C415201CFCCF00B3B012 /* RootKeyArray.json in Resources */,
 				60D6C411201CFCCF00B3B012 /* RootKeyObject.json in Resources */,
 				60D6C40F201CFCCF00B3B012 /* DateObject.json in Resources */,
+				0ECDC1CC20A9FD3500ABF991 /* RootKeyIncorrectType.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1023,9 +1036,11 @@
 			buildActionMask = 2147483647;
 			files = (
 				60D6C414201CFCCF00B3B012 /* Object.json in Resources */,
+				0ECDC1C920A9FBE600ABF991 /* RootKeyObjectPlus.json in Resources */,
 				60D6C416201CFCCF00B3B012 /* RootKeyArray.json in Resources */,
 				60D6C412201CFCCF00B3B012 /* RootKeyObject.json in Resources */,
 				60D6C410201CFCCF00B3B012 /* DateObject.json in Resources */,
+				0ECDC1CD20A9FD3600ABF991 /* RootKeyIncorrectType.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1119,6 +1134,7 @@
 				60D6C371201CC81100B3B012 /* AnyNetworkRequest.swift in Sources */,
 				60D6C372201CC81100B3B012 /* NetworkRequest.swift in Sources */,
 				60D6C373201CC81100B3B012 /* NetworkSessionDataTask.swift in Sources */,
+				0ECDC1CF20A9FE3100ABF991 /* AnyDecodable.swift in Sources */,
 				60D6C374201CC81100B3B012 /* NetworkServiceProtocol.swift in Sources */,
 				60D6C375201CC81100B3B012 /* NetworkSession.swift in Sources */,
 				60D6C376201CC81100B3B012 /* NetworkService.swift in Sources */,

--- a/Hyperspace.xcodeproj/project.pbxproj
+++ b/Hyperspace.xcodeproj/project.pbxproj
@@ -14,6 +14,8 @@
 		0ECDC1CF20A9FE3100ABF991 /* AnyDecodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ECDC1CE20A9FE3100ABF991 /* AnyDecodable.swift */; };
 		0ECDC1D220AA03A200ABF991 /* MixedTypeObject.json in Resources */ = {isa = PBXBuildFile; fileRef = 0ECDC1D020AA039F00ABF991 /* MixedTypeObject.json */; };
 		0ECDC1D320AA03A300ABF991 /* MixedTypeObject.json in Resources */ = {isa = PBXBuildFile; fileRef = 0ECDC1D020AA039F00ABF991 /* MixedTypeObject.json */; };
+		0ECDC1D420AA3EE800ABF991 /* AnyDecodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ECDC1CE20A9FE3100ABF991 /* AnyDecodable.swift */; };
+		0ECDC1D520AA3EE900ABF991 /* AnyDecodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ECDC1CE20A9FE3100ABF991 /* AnyDecodable.swift */; };
 		3026E459202008720003A321 /* NetworkSessionTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3026E457202008470003A321 /* NetworkSessionTest.swift */; };
 		3026E45A2020087C0003A321 /* NetworkSessionTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3026E457202008470003A321 /* NetworkSessionTest.swift */; };
 		30F0735420210A890045CB01 /* HTTPTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30F07352202109F60045CB01 /* HTTPTests.swift */; };
@@ -1185,6 +1187,7 @@
 				60D6C389201CCCBE00B3B012 /* AnyNetworkRequest.swift in Sources */,
 				60D6C38A201CCCBE00B3B012 /* NetworkRequest.swift in Sources */,
 				60D6C38B201CCCBE00B3B012 /* NetworkSessionDataTask.swift in Sources */,
+				0ECDC1D520AA3EE900ABF991 /* AnyDecodable.swift in Sources */,
 				60D6C38C201CCCBE00B3B012 /* NetworkServiceProtocol.swift in Sources */,
 				60D6C38D201CCCBE00B3B012 /* NetworkSession.swift in Sources */,
 				60D6C38E201CCCBE00B3B012 /* NetworkService.swift in Sources */,
@@ -1207,6 +1210,7 @@
 				60D6C37E201CCCAE00B3B012 /* NetworkRequest.swift in Sources */,
 				60D6C37F201CCCAE00B3B012 /* NetworkSessionDataTask.swift in Sources */,
 				60D6C380201CCCAE00B3B012 /* NetworkServiceProtocol.swift in Sources */,
+				0ECDC1D420AA3EE800ABF991 /* AnyDecodable.swift in Sources */,
 				60D6C381201CCCAE00B3B012 /* NetworkSession.swift in Sources */,
 				60D6C382201CCCAE00B3B012 /* NetworkService.swift in Sources */,
 				60D6C383201CCCAE00B3B012 /* BackendServiceProtocol.swift in Sources */,

--- a/Hyperspace.xcodeproj/project.pbxproj
+++ b/Hyperspace.xcodeproj/project.pbxproj
@@ -12,6 +12,8 @@
 		0ECDC1CC20A9FD3500ABF991 /* RootKeyIncorrectType.json in Resources */ = {isa = PBXBuildFile; fileRef = 0ECDC1CA20A9FCDE00ABF991 /* RootKeyIncorrectType.json */; };
 		0ECDC1CD20A9FD3600ABF991 /* RootKeyIncorrectType.json in Resources */ = {isa = PBXBuildFile; fileRef = 0ECDC1CA20A9FCDE00ABF991 /* RootKeyIncorrectType.json */; };
 		0ECDC1CF20A9FE3100ABF991 /* AnyDecodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ECDC1CE20A9FE3100ABF991 /* AnyDecodable.swift */; };
+		0ECDC1D220AA03A200ABF991 /* MixedTypeObject.json in Resources */ = {isa = PBXBuildFile; fileRef = 0ECDC1D020AA039F00ABF991 /* MixedTypeObject.json */; };
+		0ECDC1D320AA03A300ABF991 /* MixedTypeObject.json in Resources */ = {isa = PBXBuildFile; fileRef = 0ECDC1D020AA039F00ABF991 /* MixedTypeObject.json */; };
 		3026E459202008720003A321 /* NetworkSessionTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3026E457202008470003A321 /* NetworkSessionTest.swift */; };
 		3026E45A2020087C0003A321 /* NetworkSessionTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3026E457202008470003A321 /* NetworkSessionTest.swift */; };
 		30F0735420210A890045CB01 /* HTTPTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30F07352202109F60045CB01 /* HTTPTests.swift */; };
@@ -268,6 +270,7 @@
 		0ECDC1C620A9FB8300ABF991 /* RootKeyObjectPlus.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = RootKeyObjectPlus.json; sourceTree = "<group>"; };
 		0ECDC1CA20A9FCDE00ABF991 /* RootKeyIncorrectType.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = RootKeyIncorrectType.json; sourceTree = "<group>"; };
 		0ECDC1CE20A9FE3100ABF991 /* AnyDecodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyDecodable.swift; sourceTree = "<group>"; };
+		0ECDC1D020AA039F00ABF991 /* MixedTypeObject.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = MixedTypeObject.json; sourceTree = "<group>"; };
 		3026E457202008470003A321 /* NetworkSessionTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkSessionTest.swift; sourceTree = "<group>"; };
 		30F07352202109F60045CB01 /* HTTPTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPTests.swift; sourceTree = "<group>"; };
 		30F073562021720B0045CB01 /* MockBackendService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockBackendService.swift; sourceTree = "<group>"; };
@@ -623,6 +626,7 @@
 				0ECDC1CA20A9FCDE00ABF991 /* RootKeyIncorrectType.json */,
 				60D6C3FB201CFCCF00B3B012 /* Object.json */,
 				60D6C3FC201CFCCF00B3B012 /* RootKeyArray.json */,
+				0ECDC1D020AA039F00ABF991 /* MixedTypeObject.json */,
 			);
 			path = JSON;
 			sourceTree = "<group>";
@@ -1008,6 +1012,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0ECDC1D220AA03A200ABF991 /* MixedTypeObject.json in Resources */,
 				60D6C413201CFCCF00B3B012 /* Object.json in Resources */,
 				0ECDC1C820A9FBE600ABF991 /* RootKeyObjectPlus.json in Resources */,
 				60D6C415201CFCCF00B3B012 /* RootKeyArray.json in Resources */,
@@ -1035,6 +1040,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0ECDC1D320AA03A300ABF991 /* MixedTypeObject.json in Resources */,
 				60D6C414201CFCCF00B3B012 /* Object.json in Resources */,
 				0ECDC1C920A9FBE600ABF991 /* RootKeyObjectPlus.json in Resources */,
 				60D6C416201CFCCF00B3B012 /* RootKeyArray.json in Resources */,

--- a/Sources/Hyperspace/Request/AnyDecodable.swift
+++ b/Sources/Hyperspace/Request/AnyDecodable.swift
@@ -80,13 +80,3 @@ extension AnyDecodable: CustomStringConvertible {
         }
     }
 }
-
-// MARK: CustomDebugStringConvertible
-extension AnyDecodable: CustomDebugStringConvertible {
-    public var debugDescription: String {
-        switch value {
-        case let value as CustomDebugStringConvertible: return "AnyDecodable(\(value.debugDescription))"
-        default: return "AnyDecodable(\(self.description))"
-        }
-    }
-}

--- a/Sources/Hyperspace/Request/AnyDecodable.swift
+++ b/Sources/Hyperspace/Request/AnyDecodable.swift
@@ -1,0 +1,92 @@
+//
+//  AnyDecodable.swift
+//  Hyperspace-iOS
+//
+//  Created by Will McGinty on 5/14/18.
+//  Copyright © 2018 Bottle Rocket Studios. All rights reserved.
+//
+
+import Foundation
+
+///A type-erased 'Decodable' value. This type forwards Decoding to the underlying value, allowing the user to decode heterogenous dictionaries successfully using [String: AnyDecodable].
+struct AnyDecodable: Decodable {
+    let value: Any
+    
+    init<T>(_ value: T?) {
+        self.value = value ?? ()
+    }
+}
+
+extension AnyDecodable {
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        
+        if container.decodeNil() {
+            self.init(())
+        } else if let bool = try? container.decode(Bool.self) {
+            self.init(bool)
+        } else if let int = try? container.decode(Int.self) {
+            self.init(int)
+        } else if let uint = try? container.decode(UInt.self) {
+            self.init(uint)
+        } else if let double = try? container.decode(Double.self) {
+            self.init(double)
+        } else if let string = try? container.decode(String.self) {
+            self.init(string)
+        } else if let array = try? container.decode([AnyDecodable].self) {
+            self.init(array.map { $0.value })
+        } else if let dictionary = try? container.decode([String: AnyDecodable].self) {
+            self.init(dictionary.mapValues { $0.value })
+        } else {
+            throw DecodingError.dataCorruptedError(in: container, debugDescription: "AnyDecodable value could not be decoded")
+        }
+    }
+}
+
+// swiftlint:disable cyclomatic_complexity
+extension AnyDecodable: Equatable {
+    public static func == (lhs: AnyDecodable, rhs: AnyDecodable) -> Bool {
+        switch (lhs.value, rhs.value) {
+        case is (Void, Void): return true
+        case let (lhs as Bool, rhs as Bool): return lhs == rhs
+        case let (lhs as Int, rhs as Int): return lhs == rhs
+        case let (lhs as Int8, rhs as Int8): return lhs == rhs
+        case let (lhs as Int16, rhs as Int16): return lhs == rhs
+        case let (lhs as Int32, rhs as Int32): return lhs == rhs
+        case let (lhs as Int64, rhs as Int64): return lhs == rhs
+        case let (lhs as UInt, rhs as UInt): return lhs == rhs
+        case let (lhs as UInt8, rhs as UInt8): return lhs == rhs
+        case let (lhs as UInt16, rhs as UInt16): return lhs == rhs
+        case let (lhs as UInt32, rhs as UInt32): return lhs == rhs
+        case let (lhs as UInt64, rhs as UInt64): return lhs == rhs
+        case let (lhs as Float, rhs as Float): return lhs == rhs
+        case let (lhs as Double, rhs as Double): return lhs == rhs
+        case let (lhs as String, rhs as String): return lhs == rhs
+        case (let lhs as [String: AnyDecodable], let rhs as [String: AnyDecodable]): return lhs == rhs
+        case (let lhs as [AnyDecodable], let rhs as [AnyDecodable]): return lhs == rhs
+        default: return false
+        }
+    }
+}
+// enable:disable cyclomatic_complexity
+
+// MARK: CustomStringConvertible
+extension AnyDecodable: CustomStringConvertible {
+    public var description: String {
+        switch value {
+        case is Void: return String(describing: nil as Any?)
+        case let value as CustomStringConvertible: return value.description
+        default: return String(describing: value)
+        }
+    }
+}
+
+// MARK: CustomDebugStringConvertible
+extension AnyDecodable: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        switch value {
+        case let value as CustomDebugStringConvertible: return "AnyDecodable(\(value.debugDescription))"
+        default: return "AnyDecodable(\(self.description))"
+        }
+    }
+}

--- a/Sources/Hyperspace/Request/AnyNetworkRequest+DecodableContainer.swift
+++ b/Sources/Hyperspace/Request/AnyNetworkRequest+DecodableContainer.swift
@@ -49,6 +49,9 @@ extension AnyNetworkRequest where T: Decodable {
                 rootDecodingKey: String) {
         self.init(method: method, url: url, headers: headers, body: body, cachePolicy: cachePolicy, timeout: timeout) { data in
             do {
+                
+                //TODO: This logic could be extracted to accomodate a [String] of keys, but would incur additional performance costs (due to re-serialization).
+                
                 let container = try decoder.decode([String: AnyDecodable].self, from: data)
                 guard let element = container[rootDecodingKey] else {
                     let context = DecodingError.Context(codingPath: [],

--- a/Sources/Hyperspace/Request/AnyNetworkRequest+DecodableContainer.swift
+++ b/Sources/Hyperspace/Request/AnyNetworkRequest+DecodableContainer.swift
@@ -38,4 +38,31 @@ extension AnyNetworkRequest where T: Decodable {
             }
         }
     }
+    
+    public init(method: HTTP.Method,
+                url: URL,
+                headers: [HTTP.HeaderKey: HTTP.HeaderValue]? = nil,
+                body: Data? = nil,
+                cachePolicy: URLRequest.CachePolicy = NetworkRequestDefaults.defaultCachePolicy,
+                timeout: TimeInterval = NetworkRequestDefaults.defaultTimeout,
+                decoder: JSONDecoder = JSONDecoder(),
+                rootDecodingKey: String) {
+        self.init(method: method, url: url, headers: headers, body: body, cachePolicy: cachePolicy, timeout: timeout) { data in
+            do {
+                let container = try decoder.decode([String: AnyDecodable].self, from: data)
+                guard let element = container[rootDecodingKey] else {
+                    let context = DecodingError.Context(codingPath: [],
+                                                        debugDescription: "No value found at root key \"\(rootDecodingKey)\".")
+                    throw DecodingError.valueNotFound(T.self, context)
+                }
+                
+                let data = try JSONSerialization.data(withJSONObject: element.value, options: [])
+                let decodedElement = try decoder.decode(T.self, from: data)
+                return .success(decodedElement)
+
+            } catch {
+                return .failure(AnyError(error))
+            }
+        }
+    }
 }

--- a/Sources/Hyperspace/Request/AnyNetworkRequest+DecodableContainer.swift
+++ b/Sources/Hyperspace/Request/AnyNetworkRequest+DecodableContainer.swift
@@ -55,7 +55,7 @@ extension AnyNetworkRequest where T: Decodable {
                                                         debugDescription: "No value found at root key \"\(rootDecodingKey)\".")
                     throw DecodingError.valueNotFound(T.self, context)
                 }
-                
+
                 let data = try JSONSerialization.data(withJSONObject: element.value, options: [])
                 let decodedElement = try decoder.decode(T.self, from: data)
                 return .success(decodedElement)

--- a/Tests/DecodingTests.swift
+++ b/Tests/DecodingTests.swift
@@ -110,6 +110,45 @@ class DecodingTests: XCTestCase {
         let result = request.transformData(objectJSON)
         XCTAssertNil(result.value) //Should fail because RootKeyArray json contains [MockObject], not a single MockObject
     }
+    
+    func test_AnyNetworkRequesWithRootDecodableKey_SuccessfullyDecodesChildElement() {
+        let request = AnyNetworkRequest<MockObject>(method: .get, url: NetworkRequestTestDefaults.defaultURL, rootDecodingKey: "root_key")
+        let objectJSON = loadedJSONData(fromFileNamed: "RootKeyObject")
+        let result = request.transformData(objectJSON)
+        XCTAssertNotNil(result.value)
+    }
+    
+    func test_AnyNetworkRequesWithRootDecodableKey_SuccessfullyDecodesChildElements() {
+        let request = AnyNetworkRequest<[MockObject]>(method: .get, url: NetworkRequestTestDefaults.defaultURL, rootDecodingKey: "root_key")
+        let objectJSON = loadedJSONData(fromFileNamed: "RootKeyArray")
+        let result = request.transformData(objectJSON)
+        XCTAssertNotNil(result.value)
+    }
+    
+    func test_AnyNetworkRequesWithRootDecodableKey_SuccessfullyDecodesChildElementWhenExtraJSONPresent() {
+        let request = AnyNetworkRequest<MockObject>(method: .get, url: NetworkRequestTestDefaults.defaultURL, rootDecodingKey: "root_key")
+        let objectJSON = loadedJSONData(fromFileNamed: "RootKeyObjectPlus")
+        let result = request.transformData(objectJSON)
+        XCTAssertNotNil(result.value)
+    }
+    
+    func test_AnyNetworkRequesWithRootDecodableKey_FailsWithIncorrectKey() {
+        let request = AnyNetworkRequest<MockObject>(method: .get, url: NetworkRequestTestDefaults.defaultURL, rootDecodingKey: "incorrectkey")
+        let objectJSON = loadedJSONData(fromFileNamed: "RootKeyObject")
+        let result = request.transformData(objectJSON)
+        XCTAssertNil(result.value)
+        XCTAssertTrue(result.error?.error is DecodingError)
+    }
+    
+    func test_AnyNetworkRequesWithRootDecodableKey_FailsWithIncorrectType() {
+        let request = AnyNetworkRequest<MockObject>(method: .get, url: NetworkRequestTestDefaults.defaultURL, rootDecodingKey: "root_key")
+        let objectJSON = loadedJSONData(fromFileNamed: "RootKeyIncorrectType")
+        let result = request.transformData(objectJSON)
+        XCTAssertNil(result.value)
+        XCTAssertTrue(result.error?.error is DecodingError)
+    }
+    
+    // MARK: - Helper
 
     private func loadedJSONData(fromFileNamed name: String) -> Data {
         let bundle = Bundle(for: DecodingTests.self)

--- a/Tests/DecodingTests.swift
+++ b/Tests/DecodingTests.swift
@@ -148,6 +148,81 @@ class DecodingTests: XCTestCase {
         XCTAssertTrue(result.error?.error is DecodingError)
     }
     
+    func test_AnyDecodable_testFunctionalJSONDecoding() {
+        let mixedJSON = loadedJSONData(fromFileNamed: "MixedTypeObject")
+        let dictionary = try! JSONDecoder().decode([String: AnyDecodable].self, from: mixedJSON)
+        
+        XCTAssertEqual(dictionary["boolean"]?.value as! Bool, true)
+        XCTAssertEqual(dictionary["integer"]?.value as! Int, 1)
+        XCTAssertEqual(dictionary["double"]?.value as! Double, 3.14159265358979323846, accuracy: 0.001)
+        XCTAssertEqual(dictionary["string"]?.value as! String, "string")
+        XCTAssertEqual(dictionary["array"]?.value as! [Int], [1, 2, 3])
+        XCTAssertEqual(dictionary["nested"]?.value as! [String: String], ["a": "alpha", "b": "bravo", "c": "charlie"])
+    }
+    
+    func test_AnyDecodable_testEqualityOfUnderlyingType() {
+        XCTAssertEqual(AnyDecodable(true), AnyDecodable(true))
+        XCTAssertNotEqual(AnyDecodable(true), AnyDecodable(false))
+        
+        XCTAssertEqual(AnyDecodable(2), AnyDecodable(2))
+        XCTAssertNotEqual(AnyDecodable(2), AnyDecodable(4))
+        
+        XCTAssertEqual(AnyDecodable(Int8(2)), AnyDecodable(Int8(2)))
+        XCTAssertNotEqual(AnyDecodable(Int8(2)), AnyDecodable(Int8(3)))
+        
+        XCTAssertEqual(AnyDecodable(Int16(2)), AnyDecodable(Int16(2)))
+        XCTAssertNotEqual(AnyDecodable(Int16(2)), AnyDecodable(Int16(7)))
+        
+        XCTAssertEqual(AnyDecodable(Int32(2)), AnyDecodable(Int32(2)))
+        XCTAssertNotEqual(AnyDecodable(Int32(2)), AnyDecodable(Int32(3)))
+        
+        XCTAssertEqual(AnyDecodable(Int64(2)), AnyDecodable(Int64(2)))
+        XCTAssertNotEqual(AnyDecodable(Int64(2)), AnyDecodable(Int64(6)))
+        
+        XCTAssertEqual(AnyDecodable(UInt(2)), AnyDecodable(UInt(2)))
+        XCTAssertNotEqual(AnyDecodable(UInt(2)), AnyDecodable(UInt(7)))
+        
+        XCTAssertEqual(AnyDecodable(UInt8(2)), AnyDecodable(UInt8(2)))
+        XCTAssertNotEqual(AnyDecodable(UInt8(2)), AnyDecodable(UInt8(8)))
+        
+        XCTAssertEqual(AnyDecodable(UInt32(2)), AnyDecodable(UInt32(2)))
+        XCTAssertNotEqual(AnyDecodable(UInt32(2)), AnyDecodable(UInt32(6)))
+        
+        XCTAssertEqual(AnyDecodable(UInt64(2)), AnyDecodable(UInt64(2)))
+        XCTAssertNotEqual(AnyDecodable(UInt64(2)), AnyDecodable(UInt64(4)))
+        
+        XCTAssertEqual(AnyDecodable(Float(2.0)), AnyDecodable(Float(2.0)))
+        XCTAssertNotEqual(AnyDecodable(Float(2.0)), AnyDecodable(Float(5.0)))
+        
+        XCTAssertEqual(AnyDecodable(Double(2.0)), AnyDecodable(Double(2.0)))
+        XCTAssertNotEqual(AnyDecodable(Double(2.0)), AnyDecodable(Double(5.0)))
+        
+        XCTAssertEqual(AnyDecodable("string"), AnyDecodable("string"))
+        XCTAssertNotEqual(AnyDecodable("string"), AnyDecodable("a string"))
+        
+        XCTAssertEqual(AnyDecodable([AnyDecodable(1), AnyDecodable(2), AnyDecodable(3)]), AnyDecodable([AnyDecodable(1), AnyDecodable(2), AnyDecodable(3)]))
+        XCTAssertNotEqual(AnyDecodable([AnyDecodable(1), AnyDecodable(2), AnyDecodable(3)]), AnyDecodable([AnyDecodable(1), AnyDecodable(2), AnyDecodable(4)]))
+        
+        XCTAssertEqual(AnyDecodable(["val": AnyDecodable(1)]), AnyDecodable(["val": AnyDecodable(1)]))
+        XCTAssertNotEqual(AnyDecodable(["val": AnyDecodable(1)]), AnyDecodable(["val": AnyDecodable(2)]))
+    }
+    
+    // swiftlint:disable syntactic_sugar
+    func test_AnyDecodable_testDescriptionOfUnderlyingType() {
+        
+        let nilDecodable = AnyDecodable(Optional<Int>.none)
+        let mock = MockObject(title: "t", subtitle: "s")
+        let nonStringConvertible = AnyDecodable(mock)
+    
+        let obj = NSObject()
+        let stringConvertible = AnyDecodable(obj)
+        
+        XCTAssertEqual(nilDecodable.description, String(describing: nil as Any?))
+        XCTAssertEqual(nonStringConvertible.description, String(describing: mock))
+        XCTAssertEqual(stringConvertible.description, obj.description)
+    }
+    // swiftlint:enable syntactic_sugar
+    
     // MARK: - Helper
 
     private func loadedJSONData(fromFileNamed name: String) -> Data {

--- a/Tests/Helper/JSON/MixedTypeObject.json
+++ b/Tests/Helper/JSON/MixedTypeObject.json
@@ -1,0 +1,13 @@
+{
+    "boolean": true,
+    "null": null,
+    "integer": 1,
+    "double": 3.14159265358979323846,
+    "string": "string",
+    "array": [1, 2, 3],
+    "nested": {
+        "a": "alpha",
+        "b": "bravo",
+        "c": "charlie"
+    }
+}

--- a/Tests/Helper/JSON/RootKeyIncorrectType.json
+++ b/Tests/Helper/JSON/RootKeyIncorrectType.json
@@ -1,0 +1,6 @@
+{
+    "root_key": {
+        "latitude": 0,
+        "longitude": 0
+    }
+}

--- a/Tests/Helper/JSON/RootKeyObjectPlus.json
+++ b/Tests/Helper/JSON/RootKeyObjectPlus.json
@@ -1,0 +1,9 @@
+{
+    "root_key": {
+        "title": "Title",
+        "subtitle": "Subtitle"
+    },
+    "another_key": "String value",
+    "another_key_key": true
+}
+

--- a/Tests/Helper/JSON/RootKeyObjectPlus.json
+++ b/Tests/Helper/JSON/RootKeyObjectPlus.json
@@ -4,6 +4,6 @@
         "subtitle": "Subtitle"
     },
     "another_key": "String value",
-    "another_key_key": true
+    "another_key_key": "s"
 }
 

--- a/Tests/Helper/Mocks/MockDecodableContainer.swift
+++ b/Tests/Helper/Mocks/MockDecodableContainer.swift
@@ -12,6 +12,11 @@ import Hyperspace
 struct MockObject: Decodable {
     let title: String
     let subtitle: String
+    
+    init(title: String, subtitle: String) {
+        self.title = title
+        self.subtitle = subtitle
+    }
 }
 
 struct MockDate: Decodable {


### PR DESCRIPTION
This provides an implementation for being able to being decoding a JSON blob at an arbitrary String 'rootKey'. We currently have similar functionality using the `DecodableContainerType`, but this involves the generation of a type for each possible key, and so is enforced at compile time.

This method (I have kept `DecodableContainerType` available in the interface) sacrifices some run time performance for the ability to provide that String at runtime.

While the current implementation accept only a single String parameter, the same logic could be applied to an array of Strings at the cost of additional performance.