### PR TITLE
Make modifying a network request simpler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,11 @@
     
 * Separated the generation/encoding of the URL query from the `NetworkRequest` object into an extension `URL`.
     [Will McGinty](https://github.com/wmcginty)
-    [#40](https://github.com/BottleRocketStudios/iOS-Hyperspace/pull/41)
+    [#40](https://github.com/BottleRocketStudios/iOS-Hyperspace/pull/40)
+    
+* Add functionality to `NetworkReqest` to allow for replacing and adding to the HTTP headers.
+    [Will McGinty](https://github.com/wmcginty)
+    [#40](https://github.com/BottleRocketStudios/iOS-Hyperspace/pull/43)
 
 ##### Bug Fixes
 

--- a/Sources/Hyperspace/Request/NetworkRequest.swift
+++ b/Sources/Hyperspace/Request/NetworkRequest.swift
@@ -114,12 +114,29 @@ public extension NetworkRequest {
         return request
     }
     
+    /// Adds the specified headers to the HTTP headers already attached to the `NetworkRequest`.
+    ///
+    /// - Parameter additionalHeaders: The HTTP headers to add to the request
+    /// - Returns: A new `NetworkReqest` with the combined HTTP headers. In the case of a collision, the value from `additionalHeaders` is preferred.
+    func addingHeaders(_ additionalHeaders: [HTTP.HeaderKey: HTTP.HeaderValue]) -> Self {
+        let modifiedHeaders = (headers ?? [:])?.merging(additionalHeaders) { return $1 }
+        return modifyingHeaders(modifiedHeaders)
+    }
+    
+    /// Modifies the HTTP headers on the `NetworkRequest`.
+    ///
+    /// - Parameter headers: The HTTP headers to add to the request.
+    /// - Returns: A new `NetworkReqest` with the given HTTP headers.
     func modifyingHeaders(_ headers: [HTTP.HeaderKey: HTTP.HeaderValue]?) -> Self {
         var copy = self
         copy.headers = headers
         return copy
     }
     
+    /// Modifies the HTTP body on the `NetworkRequest`.
+    ///
+    /// - Parameter body: The HTTP body to add to the request.
+    /// - Returns: A new `NetworkReqest` with the given HTTP body
     func modifyingBody(_ body: Data?) -> Self {
         var copy = self
         copy.body = body

--- a/Sources/Hyperspace/Request/NetworkRequest.swift
+++ b/Sources/Hyperspace/Request/NetworkRequest.swift
@@ -120,14 +120,14 @@ public extension NetworkRequest {
     /// - Returns: A new `NetworkReqest` with the combined HTTP headers. In the case of a collision, the value from `additionalHeaders` is preferred.
     func addingHeaders(_ additionalHeaders: [HTTP.HeaderKey: HTTP.HeaderValue]) -> Self {
         let modifiedHeaders = (headers ?? [:])?.merging(additionalHeaders) { return $1 }
-        return modifyingHeaders(modifiedHeaders)
+        return usingHeaders(modifiedHeaders)
     }
     
     /// Modifies the HTTP headers on the `NetworkRequest`.
     ///
     /// - Parameter headers: The HTTP headers to add to the request.
     /// - Returns: A new `NetworkReqest` with the given HTTP headers.
-    func modifyingHeaders(_ headers: [HTTP.HeaderKey: HTTP.HeaderValue]?) -> Self {
+    func usingHeaders(_ headers: [HTTP.HeaderKey: HTTP.HeaderValue]?) -> Self {
         var copy = self
         copy.headers = headers
         return copy
@@ -137,7 +137,7 @@ public extension NetworkRequest {
     ///
     /// - Parameter body: The HTTP body to add to the request.
     /// - Returns: A new `NetworkReqest` with the given HTTP body
-    func modifyingBody(_ body: Data?) -> Self {
+    func usingBody(_ body: Data?) -> Self {
         var copy = self
         copy.body = body
         return copy

--- a/Sources/Hyperspace/Request/NetworkRequest.swift
+++ b/Sources/Hyperspace/Request/NetworkRequest.swift
@@ -39,10 +39,10 @@ public protocol NetworkRequest {
     var url: URL { get }
     
     /// The header field keys/values to use when executing this network request.
-    var headers: [HTTP.HeaderKey: HTTP.HeaderValue]? { get }
+    var headers: [HTTP.HeaderKey: HTTP.HeaderValue]? { get set }
     
     /// The payload body for this network request, if any.
-    var body: Data? { get }
+    var body: Data? { get set }
     
     /// The cache policy to use when executing this network request.
     var cachePolicy: URLRequest.CachePolicy { get }
@@ -77,7 +77,7 @@ public struct NetworkRequestDefaults {
     
     public static var defaultTimeout: TimeInterval = 30
     
-public static func dataTransformer<T: Decodable, E: DecodingFailureInitializable>(for decoder: JSONDecoder) -> (Data) -> Result<T, E> {
+    public static func dataTransformer<T: Decodable, E: DecodingFailureInitializable>(for decoder: JSONDecoder) -> (Data) -> Result<T, E> {
         return { data in
             do {
                 let decodedResponse: T = try decoder.decode(T.self, from: data)
@@ -112,6 +112,18 @@ public extension NetworkRequest {
         request.allHTTPHeaderFields = rawHeaders
         
         return request
+    }
+    
+    func modifyingHeaders(_ headers: [HTTP.HeaderKey: HTTP.HeaderValue]?) -> Self {
+        var copy = self
+        copy.headers = headers
+        return copy
+    }
+    
+    func modifyingBody(_ body: Data?) -> Self {
+        var copy = self
+        copy.body = body
+        return copy
     }
 }
 

--- a/Tests/NetworkRequestTests.swift
+++ b/Tests/NetworkRequestTests.swift
@@ -106,7 +106,7 @@ class NetworkRequestTests: XCTestCase {
     func test_NetworkRequest_ModifyingBody() {
         let body = Data(bytes: [1, 2, 3, 4, 5, 6, 7, 8])
         let request = SimpleGETRequest()
-        let modified = request.modifyingBody(body)
+        let modified = request.usingBody(body)
         
         XCTAssertEqual(modified.body, body)
         XCTAssertEqual(modified.headers, request.headers)
@@ -119,7 +119,7 @@ class NetworkRequestTests: XCTestCase {
     func test_NetworkRequest_ModifyingHeaders() {
         let headers: [HTTP.HeaderKey: HTTP.HeaderValue] = [.authorization: HTTP.HeaderValue(rawValue: "auth")]
         let request = SimpleGETRequest()
-        let modified = request.modifyingHeaders([.authorization: HTTP.HeaderValue(rawValue: "auth")])
+        let modified = request.usingHeaders([.authorization: HTTP.HeaderValue(rawValue: "auth")])
         
         XCTAssertEqual(modified.body, request.body)
         XCTAssertEqual(modified.headers, headers)

--- a/Tests/NetworkRequestTests.swift
+++ b/Tests/NetworkRequestTests.swift
@@ -128,6 +128,38 @@ class NetworkRequestTests: XCTestCase {
         XCTAssertEqual(modified.cachePolicy, request.cachePolicy)
         XCTAssertEqual(modified.timeout, request.timeout)
     }
+    
+    func test_NetworkRequest_AddingHeaders() {
+        let request = SimpleGETRequest()
+        let headers = [HTTP.HeaderKey.authorization: HTTP.HeaderValue(rawValue: "some_value")]
+        let new = request.addingHeaders(headers)
+        let headers2 = [HTTP.HeaderKey.contentType: HTTP.HeaderValue(rawValue: "some_value")]
+        let final = new.addingHeaders(headers2)
+        
+        let finalHeaders = final.headers
+        XCTAssertNotNil(finalHeaders?[.authorization])
+        XCTAssertNotNil(finalHeaders?[.contentType])
+    }
+    
+    func test_NetworkRequest_AddingHeadersWhenNonePresent() {
+        var request = SimpleGETRequest()
+        request.headers = nil
+        
+        let headers = [HTTP.HeaderKey.authorization: HTTP.HeaderValue(rawValue: "some_value")]
+        let final = request.addingHeaders(headers)
+        
+        let finalHeaders = final.headers
+        XCTAssertNotNil(finalHeaders?[.authorization])
+    }
+    
+    func test_NetworkRequest_CollisionsPrefersNewHeadersWhenAddingHeaders() {
+        let request = SimpleGETRequest().addingHeaders([.authorization: HTTP.HeaderValue(rawValue: "some_value")])
+        let accessToken = "access_token"
+        let final = request.addingHeaders([.authorization: HTTP.HeaderValue(rawValue: accessToken)])
+        
+        let finalHeaders = final.headers
+        XCTAssertEqual(finalHeaders?[.authorization]?.rawValue, accessToken)
+    }
 
     // MARK: - Private
     

--- a/Tests/NetworkRequestTests.swift
+++ b/Tests/NetworkRequestTests.swift
@@ -103,6 +103,32 @@ class NetworkRequestTests: XCTestCase {
         XCTAssertNotNil(result.value)
     }
     
+    func test_NetworkRequest_ModifyingBody() {
+        let body = Data(bytes: [1, 2, 3, 4, 5, 6, 7, 8])
+        let request = SimpleGETRequest()
+        let modified = request.modifyingBody(body)
+        
+        XCTAssertEqual(modified.body, body)
+        XCTAssertEqual(modified.headers, request.headers)
+        XCTAssertEqual(modified.url, request.url)
+        XCTAssertEqual(modified.method, request.method)
+        XCTAssertEqual(modified.cachePolicy, request.cachePolicy)
+        XCTAssertEqual(modified.timeout, request.timeout)
+    }
+    
+    func test_NetworkRequest_ModifyingHeaders() {
+        let headers: [HTTP.HeaderKey: HTTP.HeaderValue] = [.authorization: HTTP.HeaderValue(rawValue: "auth")]
+        let request = SimpleGETRequest()
+        let modified = request.modifyingHeaders([.authorization: HTTP.HeaderValue(rawValue: "auth")])
+        
+        XCTAssertEqual(modified.body, request.body)
+        XCTAssertEqual(modified.headers, headers)
+        XCTAssertEqual(modified.url, request.url)
+        XCTAssertEqual(modified.method, request.method)
+        XCTAssertEqual(modified.cachePolicy, request.cachePolicy)
+        XCTAssertEqual(modified.timeout, request.timeout)
+    }
+
     // MARK: - Private
     
     private func assertParameters<T: NetworkRequest, U>(method: String = NetworkRequestTests.defaultRequestMethod.rawValue,


### PR DESCRIPTION
I'm currently looking at creating an alternate `BackendService` which will handle automatically authenticating requests. In order to do this it, it would be good if it were simpler to modify any given `NetworkRequest` object, without having to know the concrete type.
