### PR TITLE
Add functionality to easily use `dataTransformer` extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@
 * Simplify usage of `DecodableContainer` types with `JSONDecoder`
     [Will McGinty](https://github.com/wmcginty)
     [#40](https://github.com/BottleRocketStudios/iOS-Hyperspace/pull/44)
+    
+* Simplify usage of `dataTransfomer` extensions with custom error types
+    [Will McGinty](https://github.com/wmcginty)
+    [#47](https://github.com/BottleRocketStudios/iOS-Hyperspace/pull/47)
 
 ##### Bug Fixes
 

--- a/Sources/Hyperspace/Request/NetworkRequest.swift
+++ b/Sources/Hyperspace/Request/NetworkRequest.swift
@@ -78,15 +78,23 @@ public struct NetworkRequestDefaults {
     
     public static var defaultTimeout: TimeInterval = 30
     
-    public static func dataTransformer<ResponseType: Decodable, ErrorType: DecodingFailureInitializable>(for decoder: JSONDecoder) -> (Data) -> Result<ResponseType, ErrorType> {
+    public typealias CatchErrorTransformer<E> = (Swift.Error, Data) -> E
+    
+    public static func dataTransformer<ResponseType: Decodable, ErrorType>(for decoder: JSONDecoder, catchTransformer: @escaping CatchErrorTransformer<ErrorType>) -> (Data) -> Result<ResponseType, ErrorType> {
         return { data in
             do {
                 let decodedResponse: ResponseType = try decoder.decode(ResponseType.self, from: data)
                 return .success(decodedResponse)
             } catch {
-                guard let decodingError = error as? DecodingError else { fatalError("JSONDecoder should always throw a DecodingError.") }
-                return .failure(ErrorType(decodingError: decodingError, data: data))
+                return .failure(catchTransformer(error, data))
             }
+        }
+    }
+    
+    public static func dataTransformer<ResponseType: Decodable, ErrorType: DecodingFailureInitializable>(for decoder: JSONDecoder) -> (Data) -> Result<ResponseType, ErrorType> {
+        return dataTransformer(for: decoder) {
+            guard let decodingError = $0 as? DecodingError else { fatalError("JSONDecoder should always throw a DecodingError.") }
+            return ErrorType(decodingError: decodingError, data: $1)
         }
     }
 }


### PR DESCRIPTION
This makes it much easier to use the Decodable `dataTransformer` extensions with custom errors types. You know only must specify how to map from `Swift.Error -> E` in the case of failure.