### PR TITLE
Misc cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@
     [Tyler Milner](https://github.com/tylermilner)
     [#49](https://github.com/BottleRocketStudios/iOS-Hyperspace/pull/49)
     [#50](https://github.com/BottleRocketStudios/iOS-Hyperspace/pull/50)
+    
+* Implemented synthesized `Equatable` and `Hashable` conformance that was introduced in Swift 4.1.
+    [Tyler Milner](https://github.com/tylermilner)
+    [#51](https://github.com/BottleRocketStudios/iOS-Hyperspace/pull/51)
 
 ##### Bug Fixes
 

--- a/Examples/Playground/Hyperspace.playground/Contents.swift
+++ b/Examples/Playground/Hyperspace.playground/Contents.swift
@@ -69,10 +69,7 @@ struct CreatePostRequest: NetworkRequest {
     var method: HTTP.Method = .post
     var url = URL(string: "http://jsonplaceholder.typicode.com/posts")!
     var headers: [HTTP.HeaderKey: HTTP.HeaderValue]? = [.contentType: .applicationJSON]
-    var body: Data? {
-        let encoder = JSONEncoder()
-        return try? encoder.encode(newPost)
-    }
+    var body: Data?
     
     // Define any custom properties needed
     private let newPost: NewPost
@@ -80,6 +77,9 @@ struct CreatePostRequest: NetworkRequest {
     // Initializer
     init(newPost: NewPost) {
         self.newPost = newPost
+        
+        let encoder = JSONEncoder()
+        self.body = try? encoder.encode(newPost)
     }
 }
 

--- a/Sources/Hyperspace/HTTP/HTTP.swift
+++ b/Sources/Hyperspace/HTTP/HTTP.swift
@@ -31,8 +31,6 @@ public struct HTTP {
     
     /// Represents the key portion of a HTTP header field key-value pair.
     public struct HeaderKey: RawRepresentable {
-        public typealias RawValue = String
-        
         public var rawValue: String
         
         public init(rawValue: String) {
@@ -42,8 +40,6 @@ public struct HTTP {
     
     /// Represents the value portion of a HTTP header field key-value pair.
     public struct HeaderValue: RawRepresentable {
-        public typealias RawValue = String
-        
         public var rawValue: String
         
         public init(rawValue: String) {

--- a/Sources/Hyperspace/HTTP/HTTP.swift
+++ b/Sources/Hyperspace/HTTP/HTTP.swift
@@ -30,7 +30,7 @@ public struct HTTP {
     }
     
     /// Represents the key portion of a HTTP header field key-value pair.
-    public struct HeaderKey: RawRepresentable {
+    public struct HeaderKey: RawRepresentable, Equatable, Hashable {
         public var rawValue: String
         
         public init(rawValue: String) {
@@ -39,7 +39,7 @@ public struct HTTP {
     }
     
     /// Represents the value portion of a HTTP header field key-value pair.
-    public struct HeaderValue: RawRepresentable {
+    public struct HeaderValue: RawRepresentable, Equatable {
         public var rawValue: String
         
         public init(rawValue: String) {
@@ -49,7 +49,7 @@ public struct HTTP {
     
     /// Represents a HTTP status code.
     public enum Status {
-        public struct Success: RawRepresentable {
+        public struct Success: RawRepresentable, Equatable {
             public var rawValue: Int
             
             public init(rawValue: Int) {
@@ -57,7 +57,7 @@ public struct HTTP {
             }
         }
         
-        public struct Redirection: RawRepresentable {
+        public struct Redirection: RawRepresentable, Equatable {
             public var rawValue: Int
             
             public init(rawValue: Int) {
@@ -65,7 +65,7 @@ public struct HTTP {
             }
         }
         
-        public struct ClientError: RawRepresentable {
+        public struct ClientError: RawRepresentable, Equatable {
             public var rawValue: Int
             
             public init(rawValue: Int) {
@@ -73,7 +73,7 @@ public struct HTTP {
             }
         }
         
-        public struct ServerError: RawRepresentable {
+        public struct ServerError: RawRepresentable, Equatable {
             public var rawValue: Int
             
             public init(rawValue: Int) {
@@ -104,7 +104,7 @@ public struct HTTP {
     }
     
     /// Represents a HTTP response.
-    public struct Response {
+    public struct Response: Equatable {
         
         /// The raw HTTP status code for this response.
         public let code: Int
@@ -247,40 +247,4 @@ extension HTTP.Status.ServerError {
     public static let loopDetected = HTTP.Status.ServerError(rawValue: 508)
     public static let notExtended = HTTP.Status.ServerError(rawValue: 510)
     public static let networkAuthenticationRequired = HTTP.Status.ServerError(rawValue: 511)
-}
-
-// MARK: - Hashable Implementations
-
-extension HTTP.HeaderKey: Hashable {
-    public var hashValue: Int {
-        return rawValue.hashValue
-    }
-}
-
-// MARK: - Equatable Implementations
-
-extension HTTP.HeaderKey: Equatable {
-    public static func == (lhs: HTTP.HeaderKey, rhs: HTTP.HeaderKey) -> Bool {
-        return lhs.rawValue == rhs.rawValue
-    }
-}
-
-extension HTTP.HeaderValue: Equatable {
-    public static func == (lhs: HTTP.HeaderValue, rhs: HTTP.HeaderValue) -> Bool {
-        return lhs.rawValue == rhs.rawValue
-    }
-}
-
-extension HTTP.Status.Success: Equatable { }
-
-extension HTTP.Status.Redirection: Equatable { }
-
-extension HTTP.Status.ClientError: Equatable { }
-
-extension HTTP.Status.ServerError: Equatable { }
-
-extension HTTP.Response: Equatable {
-    public static func == (lhs: HTTP.Response, rhs: HTTP.Response) -> Bool {
-        return lhs.code == rhs.code && lhs.data == rhs.data
-    }
 }

--- a/Sources/Hyperspace/Service/Network/NetworkServiceProtocol.swift
+++ b/Sources/Hyperspace/Service/Network/NetworkServiceProtocol.swift
@@ -16,7 +16,7 @@ import Foundation
 import Result
 
 /// Represents an error that occurred when executing a NetworkRequest using a NetworkService.
-public enum NetworkServiceError: Error {
+public enum NetworkServiceError: Error, Equatable {
     case unknownError
     case unknownStatusCode
     case redirection
@@ -29,13 +29,13 @@ public enum NetworkServiceError: Error {
 }
 
 /// Represents the successful result of executing a NetworkRequest using a NetworkService.
-public struct NetworkServiceSuccess {
+public struct NetworkServiceSuccess: Equatable {
     public let data: Data
     public let response: HTTP.Response
 }
 
 /// Represents the failed result of executing a NetworkRequest using a NetworkService.
-public struct NetworkServiceFailure: Error {
+public struct NetworkServiceFailure: Error, Equatable {
     public let error: NetworkServiceError
     public let response: HTTP.Response?
 }
@@ -61,45 +61,4 @@ public protocol NetworkServiceProtocol {
 
     /// Cancels all currently running tasks
     func cancelAllTasks()
-}
-
-// MARK: - Equatable Implementations
-
-extension NetworkServiceError: Equatable {
-    public static func == (lhs: NetworkServiceError, rhs: NetworkServiceError) -> Bool {
-        switch (lhs, rhs) {
-        case (.unknownError, .unknownError):
-            return true
-        case (.unknownStatusCode, .unknownStatusCode):
-            return true
-        case (.redirection, .redirection):
-            return true
-        case (.clientError(let lhsError), .clientError(let rhsError)):
-            return lhsError == rhsError
-        case (.serverError(let lhsError), .serverError(let rhsError)):
-            return lhsError == rhsError
-        case (.noData, .noData):
-            return true
-        case (.noInternetConnection, .noInternetConnection):
-            return true
-        case (.timedOut, .timedOut):
-            return true
-        case (.cancelled, .cancelled):
-            return true
-        default:
-            return false
-        }
-    }
-}
-
-extension NetworkServiceSuccess: Equatable {
-    public static func == (lhs: NetworkServiceSuccess, rhs: NetworkServiceSuccess) -> Bool {
-        return lhs.data == rhs.data && lhs.response == rhs.response
-    }
-}
-
-extension NetworkServiceFailure: Equatable {
-    public static func == (lhs: NetworkServiceFailure, rhs: NetworkServiceFailure) -> Bool {
-        return lhs.error == rhs.error && lhs.response == rhs.response
-    }
 }

--- a/Tests/Helper/Test Defaults/NetworkRequestTestDefaults.swift
+++ b/Tests/Helper/Test Defaults/NetworkRequestTestDefaults.swift
@@ -11,7 +11,7 @@ import Hyperspace
 import Result
 
 class NetworkRequestTestDefaults {
-    struct DefaultModel: Codable {
+    struct DefaultModel: Codable, Equatable {
         let title: String
     }
     
@@ -38,10 +38,4 @@ class NetworkRequestTestDefaults {
     static let defaultURL = URL(string: "https://apple.com")!
     static let defaultCachePolicy: URLRequest.CachePolicy = .useProtocolCachePolicy
     static let defaultTimeout: TimeInterval = 1.0
-}
-
-extension NetworkRequestTestDefaults.DefaultModel: Equatable {
-    public static func == (lhs: NetworkRequestTestDefaults.DefaultModel, rhs: NetworkRequestTestDefaults.DefaultModel) -> Bool {
-        return lhs.title == rhs.title
-    }
 }


### PR DESCRIPTION
* Implemented synthesized `Equatable` and `Hashable` conformance.
* Fixed compilation error in main playground.
* Minor cleanup of typealias in `HTTP.HeaderKey/Value` since the type can be inferred.