### PR TITLE
Feature/cancellation

### DIFF
--- a/Examples/Hyperspace-iOSExample/ViewController.swift
+++ b/Examples/Hyperspace-iOSExample/ViewController.swift
@@ -50,8 +50,8 @@ class ViewController: UIViewController {
 extension ViewController {
     private func getUser() {
         let getUserRequest = GetUserRequest(userId: 1)
-        
-        preferredBackendService.execute(request: getUserRequest) { [weak self] result in
+        let source = CancellationSource()
+        preferredBackendService.execute(request: getUserRequest, cancellationToken: source.token) { [weak self] result in
             debugPrint("Get user result: \(result)")
             
             switch result {
@@ -61,6 +61,8 @@ extension ViewController {
                 self?.presentAlert(titled: "Error", message: "\(error)")
             }
         }
+        
+        source.cancel()
     }
     
     private func createPost(titled title: String) {

--- a/Hyperspace.xcodeproj/project.pbxproj
+++ b/Hyperspace.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0E00FDD0221CB8BF00141E6A /* Cancellation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E00FDCF221CB8BF00141E6A /* Cancellation.swift */; };
 		0E29092D21349F600031F67C /* DecodingFailureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E29092B21349F320031F67C /* DecodingFailureTests.swift */; };
 		0E29092E21349F610031F67C /* DecodingFailureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E29092B21349F320031F67C /* DecodingFailureTests.swift */; };
 		0E347E5B2155A7A500BF18FA /* AnyError+Request.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E347E5A2155A7A500BF18FA /* AnyError+Request.swift */; };
@@ -330,6 +331,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0E00FDCF221CB8BF00141E6A /* Cancellation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cancellation.swift; sourceTree = "<group>"; };
 		0E29092B21349F320031F67C /* DecodingFailureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecodingFailureTests.swift; sourceTree = "<group>"; };
 		0E347E5A2155A7A500BF18FA /* AnyError+Request.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AnyError+Request.swift"; sourceTree = "<group>"; };
 		0E347E6221599B5900BF18FA /* XCTestCase+JSON.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+JSON.swift"; sourceTree = "<group>"; };
@@ -713,6 +715,7 @@
 				0E81B49520AC85B600DC1F4E /* Recovery */,
 				60AC83481FF596B600120172 /* Network */,
 				60AC834D1FF596B600120172 /* Backend */,
+				0E00FDCF221CB8BF00141E6A /* Cancellation.swift */,
 			);
 			path = Service;
 			sourceTree = "<group>";
@@ -1327,6 +1330,7 @@
 				60D6C376201CC81100B3B012 /* NetworkService.swift in Sources */,
 				626DA6B220A34EB600C40611 /* BackendServiceHelper.swift in Sources */,
 				60D6C377201CC81100B3B012 /* BackendServiceProtocol.swift in Sources */,
+				0E00FDD0221CB8BF00141E6A /* Cancellation.swift in Sources */,
 				B4C32C2C201E9F2D00FC82C1 /* NetworkActivityIndicatable.swift in Sources */,
 				60D6C378201CC81100B3B012 /* BackendService.swift in Sources */,
 				0EFB544A2204CC1500949F24 /* TrustValidatingNetworkService.swift in Sources */,

--- a/Hyperspace.xcodeproj/project.pbxproj
+++ b/Hyperspace.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		0E00FDD0221CB8BF00141E6A /* Cancellation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E00FDCF221CB8BF00141E6A /* Cancellation.swift */; };
+		0E00FDD1221CBA6B00141E6A /* Cancellation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E00FDCF221CB8BF00141E6A /* Cancellation.swift */; };
+		0E00FDD2221CBA6C00141E6A /* Cancellation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E00FDCF221CB8BF00141E6A /* Cancellation.swift */; };
 		0E29092D21349F600031F67C /* DecodingFailureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E29092B21349F320031F67C /* DecodingFailureTests.swift */; };
 		0E29092E21349F610031F67C /* DecodingFailureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E29092B21349F320031F67C /* DecodingFailureTests.swift */; };
 		0E347E5B2155A7A500BF18FA /* AnyError+Request.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E347E5A2155A7A500BF18FA /* AnyError+Request.swift */; };
@@ -715,7 +717,6 @@
 				0E81B49520AC85B600DC1F4E /* Recovery */,
 				60AC83481FF596B600120172 /* Network */,
 				60AC834D1FF596B600120172 /* Backend */,
-				0E00FDCF221CB8BF00141E6A /* Cancellation.swift */,
 			);
 			path = Service;
 			sourceTree = "<group>";
@@ -723,6 +724,7 @@
 		60AC83481FF596B600120172 /* Network */ = {
 			isa = PBXGroup;
 			children = (
+				0E00FDCF221CB8BF00141E6A /* Cancellation.swift */,
 				B4C32C2B201E9F2D00FC82C1 /* NetworkActivityIndicatable.swift */,
 				60AC83491FF596B600120172 /* NetworkSessionDataTask.swift */,
 				60AC834A1FF596B600120172 /* NetworkServiceProtocol.swift */,
@@ -1394,6 +1396,7 @@
 				0E81B4A420ADE0E100DC1F4E /* JSONDecoder+DecodableContainer.swift in Sources */,
 				60D6C38E201CCCBE00B3B012 /* NetworkService.swift in Sources */,
 				626DA6B420A3584900C40611 /* BackendServiceHelper.swift in Sources */,
+				0E00FDD2221CBA6C00141E6A /* Cancellation.swift in Sources */,
 				60D6C38F201CCCBE00B3B012 /* BackendServiceProtocol.swift in Sources */,
 				B4C32C2E201E9F2D00FC82C1 /* NetworkActivityIndicatable.swift in Sources */,
 				0EFB544C2204CC1600949F24 /* TrustValidatingNetworkService.swift in Sources */,
@@ -1426,6 +1429,7 @@
 				0E81B4A320ADE0E100DC1F4E /* JSONDecoder+DecodableContainer.swift in Sources */,
 				60D6C383201CCCAE00B3B012 /* BackendServiceProtocol.swift in Sources */,
 				626DA6B320A3584800C40611 /* BackendServiceHelper.swift in Sources */,
+				0E00FDD1221CBA6B00141E6A /* Cancellation.swift in Sources */,
 				30F0735E202205350045CB01 /* URL+Additions.swift in Sources */,
 				B4C32C2D201E9F2D00FC82C1 /* NetworkActivityIndicatable.swift in Sources */,
 				0EFB544B2204CC1500949F24 /* TrustValidatingNetworkService.swift in Sources */,

--- a/Sources/Certificate Pinning/TrustValidatingNetworkService.swift
+++ b/Sources/Certificate Pinning/TrustValidatingNetworkService.swift
@@ -63,7 +63,7 @@ public class TrustValidatingNetworkService: NetworkServiceProtocol {
     
     // MARK: - TrustValidatingNetworkService conformance to NetworkServiceProtocol
     
-    public func execute(request: URLRequest, completion: @escaping NetworkServiceCompletion) {
+    public func execute(request: URLRequest, cancellationToken: CancellationSource.Token? = nil, completion: @escaping NetworkServiceCompletion) {
         networkService.execute(request: request, completion: completion)
     }
     

--- a/Sources/Certificate Pinning/TrustValidatingNetworkService.swift
+++ b/Sources/Certificate Pinning/TrustValidatingNetworkService.swift
@@ -64,7 +64,7 @@ public class TrustValidatingNetworkService: NetworkServiceProtocol {
     // MARK: - TrustValidatingNetworkService conformance to NetworkServiceProtocol
     
     public func execute(request: URLRequest, cancellationToken: CancellationSource.Token? = nil, completion: @escaping NetworkServiceCompletion) {
-        networkService.execute(request: request, completion: completion)
+        networkService.execute(request: request, cancellationToken: cancellationToken, completion: completion)
     }
     
     public func cancelTask(for request: URLRequest) {

--- a/Sources/Futures/BackendService+Futures.swift
+++ b/Sources/Futures/BackendService+Futures.swift
@@ -14,10 +14,10 @@ extension BackendServiceProtocol {
     /// - Parameters:
     ///   - request: The Request to be executed.
     /// - Returns: A Future<T.ResponseType> that resolves to the request's response type.
-    public func execute<T: Request>(request: T) -> Future<T.ResponseType, T.ErrorType> {
+    public func execute<T: Request>(request: T, cancellationToken: CancellationSource.Token? = nil) -> Future<T.ResponseType, T.ErrorType> {
         let promise = Promise<T.ResponseType, T.ErrorType>()
         
-        execute(request: request) { result in
+        execute(request: request, cancellationToken: cancellationToken) { result in
             promise.complete(result)
         }
         

--- a/Sources/Hyperspace/Service/Backend/BackendService.swift
+++ b/Sources/Hyperspace/Service/Backend/BackendService.swift
@@ -31,8 +31,8 @@ public class BackendService {
 // MARK: - BackendService Conformance to BackendServiceProtocol
 
 extension BackendService: BackendServiceProtocol {
-    public func execute<T: Request>(request: T, completion: @escaping BackendServiceCompletion<T.ResponseType, T.ErrorType>) {
-        networkService.execute(request: request.urlRequest) { result in
+    public func execute<T: Request>(request: T, cancellationToken: CancellationSource.Token? = nil, completion: @escaping BackendServiceCompletion<T.ResponseType, T.ErrorType>) {
+        networkService.execute(request: request.urlRequest, cancellationToken: cancellationToken) { result in
             switch result {
             case .success(let serviceSuccess):
                 BackendServiceHelper.handleNetworkServiceSuccess(serviceSuccess, for: request, completion: completion)
@@ -42,8 +42,8 @@ extension BackendService: BackendServiceProtocol {
         }
     }
     
-    public func execute<T: Request & Recoverable>(recoverable request: T, completion: @escaping BackendServiceCompletion<T.ResponseType, T.ErrorType>) {
-        execute(request: request) { [weak self] result in
+    public func execute<T: Request & Recoverable>(recoverable request: T, cancellationToken: CancellationSource.Token? = nil, completion: @escaping BackendServiceCompletion<T.ResponseType, T.ErrorType>) {
+        execute(request: request, cancellationToken: cancellationToken) { [weak self] result in
             switch result {
             case .success(let response):
                 BackendServiceHelper.handleResponse(response, completion: completion)

--- a/Sources/Hyperspace/Service/Backend/BackendServiceProtocol.swift
+++ b/Sources/Hyperspace/Service/Backend/BackendServiceProtocol.swift
@@ -21,7 +21,7 @@ public protocol BackendServiceProtocol {
     /// - Parameters:
     ///   - request: The Request to be executed.
     ///   - completion: The completion block to invoke when execution has finished.
-    func execute<T: Request>(request: T, completion: @escaping BackendServiceCompletion<T.ResponseType, T.ErrorType>)
+    func execute<T: Request>(request: T, cancellationToken: CancellationSource.Token?, completion: @escaping BackendServiceCompletion<T.ResponseType, T.ErrorType>)
     
     /// Cancels the task for the given request (if it is currently running).
     func cancelTask(for request: URLRequest)

--- a/Sources/Hyperspace/Service/Cancellation.swift
+++ b/Sources/Hyperspace/Service/Cancellation.swift
@@ -1,0 +1,78 @@
+//
+//  Cancellation.swift
+//  Hyperspace-iOS
+//
+//  Created by Will McGinty on 2/19/19.
+//  Copyright © 2019 Bottle Rocket Studios. All rights reserved.
+//
+
+import Foundation
+
+/// Manages cancellation tokens and signals them when cancellation is requested.
+///
+/// All `CancellationTokenSource` methods are thread safe.
+public final class CancellationSource {
+    
+    public struct Token {
+        // MARK: Properties
+        private weak var source: CancellationSource?
+        public var isCancelling: Bool { return source?.isCancelling ?? false }
+        
+        public init(source: CancellationSource?) {
+            self.source = source
+        }
+        
+        // MARK: Interface
+        public func register(closure: @escaping () -> Void) {
+            source?.register(closure)
+        }
+    }
+    
+    // MARK: Properties
+    private let lock = NSLock()
+    private var observers: [() -> Void]? = []
+    
+    // MARK: Initializers
+    public init() {}
+    
+    // MARK: Interface
+    public var isCancelling: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return observers == nil
+    }
+    
+    public var token: CancellationSource.Token { return CancellationSource.Token(source: self) }
+    
+    // MARK: Registration
+    fileprivate func register(_ handler: @escaping () -> Void) {
+        if !lockedRegister(handler) {
+            handler()
+        }
+    }
+    
+    private func lockedRegister(_ handler: @escaping () -> Void) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        
+        observers?.append(handler)
+        return observers != nil
+    }
+    
+    // MARK: Cancellation
+    public func cancel() {
+        if let observers = lockedCancel() {
+            observers.forEach { $0() }
+        }
+    }
+    
+    private func lockedCancel() -> [() -> Void]? {
+        lock.lock()
+        defer { lock.unlock() }
+        
+        let observers = self.observers
+        self.observers = nil //Transition to `isCancelling`
+        
+        return observers
+    }
+}

--- a/Sources/Hyperspace/Service/Network/Cancellation.swift
+++ b/Sources/Hyperspace/Service/Network/Cancellation.swift
@@ -1,6 +1,6 @@
 //
 //  Cancellation.swift
-//  Hyperspace-iOS
+//  Hyperspace
 //
 //  Created by Will McGinty on 2/19/19.
 //  Copyright © 2019 Bottle Rocket Studios. All rights reserved.

--- a/Sources/Hyperspace/Service/Network/NetworkService.swift
+++ b/Sources/Hyperspace/Service/Network/NetworkService.swift
@@ -45,7 +45,7 @@ public class NetworkService {
 // MARK: - NetworkService Conformance to NetworkServiceProtocol
 
 extension NetworkService: NetworkServiceProtocol {
-    public func execute(request: URLRequest, completion: @escaping NetworkServiceCompletion) {
+    public func execute(request: URLRequest, cancellationToken: CancellationSource.Token? = nil, completion: @escaping NetworkServiceCompletion) {
         let task = session.dataTask(with: request) { [weak self] (data, response, error) in
             self?.networkActivityController?.stop()
             
@@ -63,6 +63,7 @@ extension NetworkService: NetworkServiceProtocol {
         }
         
         tasks[request] = task
+        cancellationToken?.register { task.cancel() }
         task.resume()
         networkActivityController?.start()
     }

--- a/Sources/Hyperspace/Service/Network/NetworkServiceProtocol.swift
+++ b/Sources/Hyperspace/Service/Network/NetworkServiceProtocol.swift
@@ -64,7 +64,7 @@ public protocol NetworkServiceProtocol {
     /// - Parameters:
     ///   - request: The URLRequest to execute.
     ///   - completion: The completion block to be invoked when request execution is complete.
-    func execute(request: URLRequest, completion: @escaping NetworkServiceCompletion)
+    func execute(request: URLRequest, cancellationToken: CancellationSource.Token?, completion: @escaping NetworkServiceCompletion)
     
     /// Cancels the task for the given request (if it is currently running).
     func cancelTask(for request: URLRequest)


### PR DESCRIPTION
OK, as promised here is a draft PR for what a revamp to the cancellation mechanism might look like. I have somewhat implemented a `CancellationSource` into the `NetworkService` and by extension the `BackendService`. 

1) When executing the request, keep and store a `CancellationSource`:

```swift
let source = CancellationSource()
preferredBackendService.execute(request: getUserRequest, cancellationToken: source.token) { [weak self] result in
            debugPrint("Get user result: \(result)")
            
            switch result {
            case .success(let user):
                self?.presentAlert(titled: "Fetched user", message: "\(user)")
            case .failure(let error):
                self?.presentAlert(titled: "Error", message: "\(error)")
      }
}
```

At this point we could definitely provide a customization point into the creation of the token if needed, for instance:

```swift
source.token(with: UUID())
``` 

Inside Hyperspace, the `BackendService` simply passes the `CancellationSource.Token` into the `NetworkService` where it is used in generation of the request:

```swift
public func execute(request: URLRequest, cancellationToken: CancellationSource.Token? = nil, completion: @escaping NetworkServiceCompletion) {
    let task = session.dataTask(with: request) { [weak self] (data, response, error) in
        //completion handler
    }
    
    cancellationToken?.register { task.cancel() }
    //more implementation
}
```

At this point, all you have to do from the client of the `BackendService` has to do is call:

```swift
source.cancel()
```

This will cancel all the tokens that have been generated by the given `source`. In this specific case, this results in a result of : `.failure(cancelled)`
