### PR TITLE
Removed queryParameters from Request extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@
 [Will McGinty](https://github.com/wmcginty)
 [#88](https://github.com/BottleRocketStudios/iOS-Hyperspace/pull/88)
 
+* Remove the `queryParameter` property deprecated in 2.0.0.
+[Will McGinty](https://github.com/wmcginty)
+[#90](https://github.com/BottleRocketStudios/iOS-Hyperspace/pull/90)
+
 ##### Bug Fixes
 
 * None.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ struct CreatePostRequest: Request {
     // Define Request property values
     var method: HTTP.Method = .post
     var url = URL(string: "http://jsonplaceholder.typicode.com/posts")!
-    var queryParameters: [URLQueryItem]?
     var headers: [HTTP.HeaderKey: HTTP.HeaderValue]? = [.contentType: .applicationJSON]
     var body: Data? {
         let encoder = JSONEncoder()

--- a/Sources/Hyperspace/Request/Request.swift
+++ b/Sources/Hyperspace/Request/Request.swift
@@ -154,10 +154,6 @@ public struct RequestDefaults {
 // MARK: - Request Default Implementations
 
 public extension Request {
-
-    var queryParameters: [URLQueryItem]? {
-        return nil
-    }
     
     var cachePolicy: URLRequest.CachePolicy {
         return RequestDefaults.defaultCachePolicy


### PR DESCRIPTION
Address #86 

I left in the URLQueryParameterEncoder and extensions because while they are no longer part of the request, I think they're still helpful when generating URLs.