### PR TITLE
Changed AnyError's implementation of NetworkServiceFailureInitializable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 #### Enhancements
 
-* None
-
+* Changed underlying error in AnyError's NetworkServiceFailureInitializable implementation from NetworkServiceError to NetworkServiceFailure so it can return its failure response rather than nil.
+[Richard Burgess](https://github.com/rickbdotcom)
+[#95](https://github.com/BottleRocketStudios/iOS-Hyperspace/pull/95)
 
 ##### Bug Fixes
 

--- a/Sources/Hyperspace/Request/AnyError.swift
+++ b/Sources/Hyperspace/Request/AnyError.swift
@@ -57,15 +57,15 @@ extension AnyError: LocalizedError {
 extension AnyError: NetworkServiceFailureInitializable {
     
     public init(networkServiceFailure: NetworkServiceFailure) {
-        self.init(networkServiceFailure.error)
+        self.init(networkServiceFailure)
     }
     
     public var networkServiceError: NetworkServiceError {
-        return (error as? NetworkServiceError) ?? .unknownError
+        return (error as? NetworkServiceFailure)?.error ?? .unknownError
     }
     
     public var failureResponse: HTTP.Response? {
-        return nil
+        return (error as? NetworkServiceFailure)?.response
     }
 }
 

--- a/Tests/BackendServiceTests.swift
+++ b/Tests/BackendServiceTests.swift
@@ -29,8 +29,8 @@ class BackendServiceTests: XCTestCase {
         let failure = NetworkServiceFailure(error: .noInternetConnection, response: nil)
         let anyError = AnyError(networkServiceFailure: failure)
         
-        XCTAssertTrue(anyError.error is NetworkServiceError)
-        XCTAssertEqual(anyError.error as! NetworkServiceError, .noInternetConnection)
+        XCTAssertTrue(anyError.error is NetworkServiceFailure)
+        XCTAssertEqual((anyError.error as! NetworkServiceFailure).error, .noInternetConnection)
     }
     
     func test_NetworkServiceSuccess_TransformsResponseCorrectly() {

--- a/Tests/NetworkServiceTests.swift
+++ b/Tests/NetworkServiceTests.swift
@@ -145,9 +145,10 @@ class NetworkServiceTests: XCTestCase {
         XCTAssertNotEqual(NetworkServiceError.redirection, NetworkServiceError.cancelled)
     }
     
-    func test_AnyError_NeverHasResponse() {
-        let error = AnyError(networkServiceFailure: NetworkServiceFailure(error: .cancelled, response: HTTP.Response(code: 1, data: nil)))
-        XCTAssertNil(error.failureResponse)
+    func test_AnyError_HasResponse() {
+		let response = HTTP.Response(code: 1, data: nil)
+        let error = AnyError(networkServiceFailure: NetworkServiceFailure(error: .cancelled, response: response))
+        XCTAssertEqual(error.failureResponse, response)
     }
     
     // MARK: - Private

--- a/Tests/RecoverableTests.swift
+++ b/Tests/RecoverableTests.swift
@@ -147,8 +147,8 @@ class RecoverableTests: XCTestCase {
                 XCTFail("The error should not recoverable!")
                 
             case .failure(let error):
-                guard let innerError = error.error as? NetworkServiceError else { return XCTFail("The error that causes the failure should be a NetworkServiceError.") }
-                guard case let .clientError(clientError) = innerError else { return XCTFail("The error that causes the failure should be a NetworkServiceError.ClientError.") }
+                guard let innerError = error.error as? NetworkServiceFailure else { return XCTFail("The error that causes the failure should be a NetworkServiceFailure .") }
+                guard case let .clientError(clientError) = innerError.error else { return XCTFail("The error that causes the failure should be a NetworkServiceError.ClientError.") }
                 XCTAssertEqual(clientError, .unauthorized)
             }
             


### PR DESCRIPTION
To allow access to underlying failureResponse.