### PR TITLE
WIP - Improve error details when the underlying request fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@
 [Ryan Gant](https://github.com/ganttastic)
 [#102](https://github.com/BottleRocketStudios/iOS-Hyperspace/pull/102)
 
+* Added an associated type to the `unknownError` case of `NetworkServiceError`. Previously, the `Error` provided in the completion of the execution of a request was being thrown away if the `response` parameter was not a `HTTPURLResponse`. In some cases, these errors were internally mapped to a `NetworkServiceError` (`noInternetConnection`, `timedOut`, and `cancelled`), but now clients have access to all other errors that might occur (`NSURLErrorBadURL`, `NSURLErrorCannotFindHost`, `NSURLErrorDNSLookupFailed`, etc.).
+[Tyler Milner](https://github.com/tylermilner)
+[#105](https://github.com/BottleRocketStudios/iOS-Hyperspace/pull/105)
+
 ##### Bug Fixes
 
 * None

--- a/Sources/Hyperspace/Request/AnyError.swift
+++ b/Sources/Hyperspace/Request/AnyError.swift
@@ -61,7 +61,7 @@ extension AnyError: NetworkServiceFailureInitializable {
     }
     
     public var networkServiceError: NetworkServiceError {
-        return (error as? NetworkServiceFailure)?.error ?? .unknownError
+        return (error as? NetworkServiceFailure)?.error ?? .unknownError(error)
     }
     
     public var failureResponse: HTTP.Response? {

--- a/Sources/Hyperspace/Service/Network/NetworkServiceHelper.swift
+++ b/Sources/Hyperspace/Service/Network/NetworkServiceHelper.swift
@@ -56,9 +56,9 @@ private extension NetworkServiceHelper {
             case (NSURLErrorDomain, NSURLErrorCancelled):
                 return .cancelled
             default:
-                return .unknownError
+                return .unknownError($0)
             }
-            } ?? .unknownError
+        } ?? .unknownError(error)
         
         return networkError
     }

--- a/Sources/Hyperspace/Service/Network/NetworkServiceProtocol.swift
+++ b/Sources/Hyperspace/Service/Network/NetworkServiceProtocol.swift
@@ -15,8 +15,8 @@
 import Foundation
 
 /// Represents an error that occurred when executing a Request using a NetworkService.
-public enum NetworkServiceError: Error, Equatable {
-    case unknownError
+public enum NetworkServiceError: Error {
+    case unknownError(Error?)
     case unknownStatusCode
     case redirection
     case clientError(HTTP.Status.ClientError)
@@ -70,4 +70,34 @@ public protocol NetworkServiceProtocol {
 
     /// Cancels all currently running tasks
     func cancelAllTasks()
+}
+
+// MARK: - Equatable Implementations
+
+extension NetworkServiceError: Equatable {
+    
+    public static func == (lhs: NetworkServiceError, rhs: NetworkServiceError) -> Bool {
+        switch (lhs, rhs) {
+        case (.unknownError(let lhsError), .unknownError(let rhsError)):
+            return lhsError?.localizedDescription == rhsError?.localizedDescription
+        case (.unknownStatusCode, .unknownStatusCode):
+            return true
+        case (.redirection, .redirection):
+            return true
+        case (.clientError(let lhsError), .clientError(let rhsError)):
+            return lhsError == rhsError
+        case (.serverError(let lhsError), .serverError(let rhsError)):
+            return lhsError == rhsError
+        case (.noData, .noData):
+            return true
+        case (.noInternetConnection, .noInternetConnection):
+            return true
+        case (.timedOut, .timedOut):
+            return true
+        case (.cancelled, .cancelled):
+            return true
+        default:
+            return false
+        }
+    }
 }

--- a/Tests/Helper/Mocks/MockBackendService.swift
+++ b/Tests/Helper/Mocks/MockBackendService.swift
@@ -25,7 +25,7 @@ public enum MockBackendServiceError: NetworkServiceFailureInitializable, Decodin
     public var networkServiceError: NetworkServiceError {
         switch self {
         case .networkError(let error, _): return error
-        case .dataTransformationError: return .unknownError
+        case .dataTransformationError(let error): return .unknownError(error)
         }
     }
     

--- a/Tests/NetworkServiceTests.swift
+++ b/Tests/NetworkServiceTests.swift
@@ -18,7 +18,7 @@ class NetworkServiceTests: XCTestCase {
     // MARK: - Tests
     
     func test_MissingURLResponse_GeneratesUnknownError() {
-        let expectedResult = NetworkServiceFailure(error: .unknownError, response: nil)
+        let expectedResult = NetworkServiceFailure(error: .unknownError(nil), response: nil)
         executeNetworkServiceUsingMockHTTPResponse(nil, expectingResult: .failure(expectedResult))
     }
     
@@ -128,12 +128,14 @@ class NetworkServiceTests: XCTestCase {
     }
     
     func test_NetworkServiceHelper_InvalidHTTPResponsErrorUnknownError() {
-        let networkServiceFailure = NetworkServiceHelper.networkServiceFailure(for: NSError(domain: NSURLErrorDomain, code: NSURLErrorBadURL, userInfo: nil))
-        XCTAssert(networkServiceFailure.error == .unknownError)
+        let badURLError = NSError(domain: NSURLErrorDomain, code: NSURLErrorBadURL, userInfo: nil)
+        let networkServiceFailure = NetworkServiceHelper.networkServiceFailure(for: badURLError)
+        XCTAssertEqual(networkServiceFailure.error, .unknownError(badURLError))
     }
     
     func test_NetworkServiceError_Equality() {
-        XCTAssertEqual(NetworkServiceError.unknownError, NetworkServiceError.unknownError)
+        let unknownError = NSError(domain: NSURLErrorDomain, code: NSURLErrorUnknown, userInfo: nil)
+        XCTAssertEqual(NetworkServiceError.unknownError(unknownError), NetworkServiceError.unknownError(unknownError))
         XCTAssertEqual(NetworkServiceError.unknownStatusCode, NetworkServiceError.unknownStatusCode)
         XCTAssertEqual(NetworkServiceError.redirection, NetworkServiceError.redirection)
         XCTAssertEqual(NetworkServiceError.redirection, NetworkServiceError.redirection)


### PR DESCRIPTION
Added an associated type to the `unknownError` case of `NetworkServiceError`. Previously, the `Error` provided in the completion of the execution of a request was being thrown away if the `response` parameter was not a `HTTPURLResponse`. In some cases, these errors were internally mapped to a `NetworkServiceError` (`noInternetConnection`, `timedOut`, and `cancelled`), but now clients have access to all other errors that might occur (`NSURLErrorBadURL`, `NSURLErrorCannotFindHost`, `NSURLErrorDNSLookupFailed`, etc.).

Basically, instead of needing to manually map a lot more cases in [this switch](https://github.com/BottleRocketStudios/iOS-Hyperspace/blob/master/Sources/Hyperspace/Service/Network/NetworkServiceHelper.swift#L51), we now pass the underlying error through so that clients can have a more descriptive explanation of what went wrong vs just getting back a `NetworkServiceError.unknownError`.