### PR TITLE
Make TransportError inits public.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,10 @@
 [Will McGinty](https://github.com/wmcginty)
 [#117](https://github.com/BottleRocketStudios/iOS-Hyperspace/pull/117)
 
+* Make `TransportError` inits `public`..
+  [Earl Gaspard](https://github.com/earlgaspard)
+  [#121](https://github.com/BottleRocketStudios/iOS-Hyperspace/pull/121)
+
 ##### Bug Fixes
 
 * Add an assertion to `BackendService` if a GET HTTP request with body data is detected.

--- a/Sources/Hyperspace/Service/Transport/TransportResult.swift
+++ b/Sources/Hyperspace/Service/Transport/TransportResult.swift
@@ -25,7 +25,7 @@ public struct TransportError: Error, Equatable {
         
         // MARK: - Initializer
         
-        init(clientError: Error?) {
+        public init(clientError: Error?) {
             self = (clientError as? URLError).flatMap {
                 switch $0.code {
                 case .cancelled: return .cancelled
@@ -44,12 +44,12 @@ public struct TransportError: Error, Equatable {
     
     // MARK: - Initializers
     
-    init(code: Code, failingURL: URL? = nil) {
+    public init(code: Code, failingURL: URL? = nil) {
         self.code = code
         self.failingURL = failingURL
     }
     
-    init(clientError: Error?) {
+    public init(clientError: Error?) {
         let urlError = clientError as? URLError
         self.init(code: Code(clientError: clientError), failingURL: urlError?.failingURL)
     }


### PR DESCRIPTION
This PR allows the creation of TransportError when needed.