### PR TITLE
Add defaultDecoder to RequestDefaults and use as a default parameter value for initialization.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,16 +57,16 @@
 [#117](https://github.com/BottleRocketStudios/iOS-Hyperspace/pull/117)
 
 * Make `TransportError` inits `public`.
-  [Earl Gaspard](https://github.com/earlgaspard)
-  [#121](https://github.com/BottleRocketStudios/iOS-Hyperspace/pull/121)
+[Earl Gaspard](https://github.com/earlgaspard)
+[#121](https://github.com/BottleRocketStudios/iOS-Hyperspace/pull/121)
   
-  * Create a form URL encoded `HTTP.Body` convenience
-  [Will McGinty](https://github.com/wmcginty)
-  [#125](https://github.com/BottleRocketStudios/iOS-Hyperspace/pull/125)
+* Create a form URL encoded `HTTP.Body` convenience
+[Will McGinty](https://github.com/wmcginty)
+[#125](https://github.com/BottleRocketStudios/iOS-Hyperspace/pull/125)
   
-  * Add `defaultDecoder` to `RequestDefaults` and use when initializing a `Request`.
-    [Earl Gaspard](https://github.com/earlgaspard)
-    [#131](https://github.com/BottleRocketStudios/iOS-Hyperspace/pull/131)
+* Add `defaultDecoder` to `RequestDefaults` and use when initializing a `Request`.
+[Earl Gaspard](https://github.com/earlgaspard)
+[#131](https://github.com/BottleRocketStudios/iOS-Hyperspace/pull/131)
 
 ##### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,13 +56,17 @@
 [Will McGinty](https://github.com/wmcginty)
 [#117](https://github.com/BottleRocketStudios/iOS-Hyperspace/pull/117)
 
-* Make `TransportError` inits `public`..
+* Make `TransportError` inits `public`.
   [Earl Gaspard](https://github.com/earlgaspard)
   [#121](https://github.com/BottleRocketStudios/iOS-Hyperspace/pull/121)
   
   * Create a form URL encoded `HTTP.Body` convenience
   [Will McGinty](https://github.com/wmcginty)
   [#125](https://github.com/BottleRocketStudios/iOS-Hyperspace/pull/125)
+  
+  * Add `defaultDecoder` to `RequestDefaults` and use when initializing a `Request`.
+    [Earl Gaspard](https://github.com/earlgaspard)
+    [#131](https://github.com/BottleRocketStudios/iOS-Hyperspace/pull/131)
 
 ##### Bug Fixes
 

--- a/README.md
+++ b/README.md
@@ -83,8 +83,9 @@ struct NewPost: Encodable {
 
 To avoid having to define default `Request` property values for every request in your app, it can be useful to rely on the `RequestDefaults` provided by Hyperspace. These can even be customized:
 ```swift
-RequestDefaults.defaultTimeout = 60 // Default timeout is 30 seconds
 RequestDefaults.defaultCachePolicy = .reloadIgnoringLocalCacheData // Default cache policy is '.useProtocolCachePolicy'
+RequestDefaults.defaultDecoder = MyCustomDecoder() // Default decoder is JSONDecoder
+RequestDefaults.defaultTimeout = 60 // Default timeout is 30 seconds
 ```
 
 ### 3. Create a BackendService to execute your requests

--- a/Sources/Hyperspace/Extensions/Coding/CodableContainer.swift
+++ b/Sources/Hyperspace/Extensions/Coding/CodableContainer.swift
@@ -47,7 +47,7 @@ public extension Request where Response: Decodable, Error: DecodingFailureRepres
                                         body: HTTP.Body? = nil,
                                         cachePolicy: URLRequest.CachePolicy = RequestDefaults.defaultCachePolicy,
                                         timeout: TimeInterval = RequestDefaults.defaultTimeout,
-                                        decoder: JSONDecoder = JSONDecoder(),
+                                        decoder: JSONDecoder = RequestDefaults.defaultDecoder,
                                         containerType: Container.Type) where Container.Contained == Response {
         self.init(method: method, url: url, headers: headers, body: body, cachePolicy: cachePolicy, timeout: timeout,
                   successTransformer: Request.successTransformer(for: decoder, with: containerType))

--- a/Sources/Hyperspace/Extensions/Coding/Request+Decodable.swift
+++ b/Sources/Hyperspace/Extensions/Coding/Request+Decodable.swift
@@ -20,7 +20,7 @@ public extension Request where Response: Decodable, Error: DecodingFailureRepres
          body: HTTP.Body? = nil,
          cachePolicy: URLRequest.CachePolicy = RequestDefaults.defaultCachePolicy,
          timeout: TimeInterval = RequestDefaults.defaultTimeout,
-         decoder: JSONDecoder = JSONDecoder()) {
+         decoder: JSONDecoder = RequestDefaults.defaultDecoder) {
         self.init(method: method, url: url, headers: headers, body: body, cachePolicy: cachePolicy, timeout: timeout, successTransformer: Request.successTransformer(for: decoder))
     }
     

--- a/Sources/Hyperspace/Request/Request.swift
+++ b/Sources/Hyperspace/Request/Request.swift
@@ -104,6 +104,7 @@ public struct EmptyResponse {
 public struct RequestDefaults {
     
     public static var defaultCachePolicy: URLRequest.CachePolicy = .useProtocolCachePolicy
+    public static var defaultDecoder: JSONDecoder = JSONDecoder()
     public static var defaultTimeout: TimeInterval = 30
 }
 


### PR DESCRIPTION
This PR adds a `defaultDecoder` so projects can easily use a custom decoder for `Request`s it creates.