### PR TITLE
Make transportService public.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,10 @@
 [Earl Gaspard](https://github.com/earlgaspard)
 [#131](https://github.com/BottleRocketStudios/iOS-Hyperspace/pull/131)
 
+* Make `transportService` public in `BackendService`.
+[Earl Gaspard](https://github.com/earlgaspard)
+[#134](https://github.com/BottleRocketStudios/iOS-Hyperspace/pull/134)
+
 ##### Bug Fixes
 
 * Add an assertion to `BackendService` if a GET HTTP request with body data is detected.

--- a/Sources/Hyperspace/Service/Backend/BackendService.swift
+++ b/Sources/Hyperspace/Service/Backend/BackendService.swift
@@ -12,7 +12,7 @@ public class BackendService {
     
     // MARK: - Properties
     
-    private let transportService: Transporting
+    public let transportService: Transporting
     public var recoveryStrategies: [RecoveryStrategy]
     
     // MARK: - Initializer


### PR DESCRIPTION
Want to make transportService in BackendService public so I can create an extension of BackendService that can access the transportService.