### PR TITLE
Make DecodingFailure.Context properties public.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,10 @@
 [Earl Gaspard](https://github.com/earlgaspard)
 [#134](https://github.com/BottleRocketStudios/iOS-Hyperspace/pull/134)
 
+* Make `DecodingFailure.Context` properties public.
+[Earl Gaspard](https://github.com/earlgaspard)
+[#135](https://github.com/BottleRocketStudios/iOS-Hyperspace/pull/135)
+
 ##### Bug Fixes
 
 * Add an assertion to `BackendService` if a GET HTTP request with body data is detected.

--- a/Sources/Hyperspace/Service/Backend/BackendServiceProtocol.swift
+++ b/Sources/Hyperspace/Service/Backend/BackendServiceProtocol.swift
@@ -13,9 +13,15 @@ public enum DecodingFailure: Error {
     // MARK: - Context Subtype
 
     public struct Context {
-        let decodingError: DecodingError
-        let failingType: Decodable.Type
-        let response: HTTP.Response
+        public let decodingError: DecodingError
+        public let failingType: Decodable.Type
+        public let response: HTTP.Response
+        
+        public init(decodingError: DecodingError, failingType: Decodable.Type, response: HTTP.Response) {
+            self.decodingError = decodingError
+            self.failingType = failingType
+            self.response = response
+        }
     }
 
     case invalidEmptyResponse(HTTP.Response)
@@ -32,8 +38,8 @@ public enum DecodingFailure: Error {
 
     public var decodingContext: Context? {
         switch self {
+        case .invalidEmptyResponse: return nil
         case .decodingError(let context): return context
-        default: return nil
         }
     }
 


### PR DESCRIPTION
After importing Hyperspace changes to my project, I am wanting to access decodingError in DecodingFailure.Context as well as being able to create a Context for testing purposes.