### PR TITLE
Feature/async await

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 #### Enhancements
 
+* Added async / await functions for executing requests
+[Daniel Larsen](https://github.com/grandlarseny)
+[#142]https://github.com/BottleRocketStudios/iOS-Hyperspace/pull/142
+
 * Migrate to use .xcframework's when resolving depencies using Carthage
 [Will McGinty](https://github.com/wmcginty)
 [#139](https://github.com/BottleRocketStudios/iOS-Hyperspace/pull/139)

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "Thomvis/BrightFutures" "8.0.1"
+github "Thomvis/BrightFutures" "8.1.0"

--- a/Examples/Hyperspace-watchOSExample Extension/InterfaceController.swift
+++ b/Examples/Hyperspace-watchOSExample Extension/InterfaceController.swift
@@ -81,7 +81,7 @@ extension InterfaceController {
 extension WKInterfaceController {
     func presentAlert(titled title: String, message: String) {
         let dismissAction = WKAlertAction(title: "OK", style: .default) {
-            //Do nothing
+            // Do nothing
         }
         presentAlert(withTitle: title, message: message, preferredStyle: .alert, actions: [dismissAction])
     }

--- a/Examples/Shared/NetworkRequests.swift
+++ b/Examples/Shared/NetworkRequests.swift
@@ -46,7 +46,7 @@ extension Request where Response == Post, Error == AnyError {
     
     static func createPost(_ post: NewPost) -> Request<Post, AnyError> {
         return Request(method: .post, url: URL(string: "https://jsonplaceholder.typicode.com/posts")!, headers: [.contentType: .applicationJSON],
-                       body: try? HTTP.Body(post))
+                       body: try? HTTP.Body.json(post))
     }
 }
 

--- a/Hyperspace.xcodeproj/project.pbxproj
+++ b/Hyperspace.xcodeproj/project.pbxproj
@@ -179,6 +179,7 @@
 		60D6C440201D188B00B3B012 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60D6C43F201D188B00B3B012 /* ViewController.swift */; };
 		60D6C443201D188B00B3B012 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 60D6C441201D188B00B3B012 /* Main.storyboard */; };
 		60D6C445201D188B00B3B012 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 60D6C444201D188B00B3B012 /* Assets.xcassets */; };
+		65709A27272E0B9D0066361E /* BackendService+Async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65709A26272E0B9D0066361E /* BackendService+Async.swift */; };
 		B4255B59246E528C009B6D6A /* EncodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4255B57246E525F009B6D6A /* EncodingTests.swift */; };
 		B4255B5A246E528D009B6D6A /* EncodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4255B57246E525F009B6D6A /* EncodingTests.swift */; };
 		B469328F2413539700D2B650 /* TransportResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = B469328E2413539700D2B650 /* TransportResult.swift */; };
@@ -445,6 +446,7 @@
 		60D6C444201D188B00B3B012 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		60D6C446201D188B00B3B012 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		60EB8FDB1FF59FB000AC0B55 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		65709A26272E0B9D0066361E /* BackendService+Async.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BackendService+Async.swift"; sourceTree = "<group>"; };
 		B4255B57246E525F009B6D6A /* EncodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EncodingTests.swift; sourceTree = "<group>"; };
 		B469328E2413539700D2B650 /* TransportResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransportResult.swift; sourceTree = "<group>"; };
 		B476477424136071003C97E9 /* Request.URLRequestCreationStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Request.URLRequestCreationStrategy.swift; sourceTree = "<group>"; };
@@ -646,6 +648,7 @@
 			isa = PBXGroup;
 			children = (
 				60AC833D1FF596B600120172 /* Hyperspace */,
+				65709A25272E0B8E0066361E /* Async */,
 				0E4B3ADD22023BFD00D65DB5 /* Certificate Pinning */,
 				CB0DE06121E7E5EF00661F0E /* Futures */,
 				60AC82F91FF58E3600120172 /* Supporting Files */,
@@ -876,6 +879,14 @@
 				60EB8FDB1FF59FB000AC0B55 /* Info.plist */,
 			);
 			path = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		65709A25272E0B8E0066361E /* Async */ = {
+			isa = PBXGroup;
+			children = (
+				65709A26272E0B9D0066361E /* BackendService+Async.swift */,
+			);
+			path = Async;
 			sourceTree = "<group>";
 		};
 		CB0DE06121E7E5EF00661F0E /* Futures */ = {
@@ -1445,6 +1456,7 @@
 				0EF57B972203CD0B00484C01 /* AuthenticationChallenge.swift in Sources */,
 				B469328F2413539700D2B650 /* TransportResult.swift in Sources */,
 				0E03975D24EB8CD50078BA7D /* FormURLEncoder.swift in Sources */,
+				65709A27272E0B9D0066361E /* BackendService+Async.swift in Sources */,
 				0ECDC1DC20AB3B3E00ABF991 /* URLQueryParameterEncoder.swift in Sources */,
 				60D6C370201CC81100B3B012 /* CodableContainer.swift in Sources */,
 				CB0DE06321E7E62500661F0E /* BackendService+Futures.swift in Sources */,

--- a/Hyperspace.xcodeproj/project.pbxproj
+++ b/Hyperspace.xcodeproj/project.pbxproj
@@ -672,8 +672,8 @@
 		60AC831F1FF58E8B00120172 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
-				65709A28272E0F600066361E /* AsyncTests.swift */,
 				0EBF9B1C246F347800E990DC /* AnyErrorTests.swift */,
+				65709A28272E0F600066361E /* AsyncTests.swift */,
 				60D6C3F0201CFCCF00B3B012 /* BackendServiceTests.swift */,
 				0EF57B87220296A700484C01 /* CertificateHashTests.swift */,
 				0E29092B21349F320031F67C /* DecodingFailureTests.swift */,
@@ -2009,6 +2009,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
 				VALIDATE_WORKSPACE = YES;
 			};
 			name = Debug;
@@ -2032,6 +2033,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
 				VALIDATE_WORKSPACE = YES;
 			};
 			name = Release;

--- a/Hyperspace.xcodeproj/project.pbxproj
+++ b/Hyperspace.xcodeproj/project.pbxproj
@@ -1100,7 +1100,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0920;
-				LastUpgradeCheck = 0930;
+				LastUpgradeCheck = 1310;
 				ORGANIZATIONNAME = "Bottle Rocket Studios";
 				TargetAttributes = {
 					6083678A201D1AF400007247 = {
@@ -1317,7 +1317,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\nswiftlint\nelse\necho \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi";
+			shellScript = "if which swiftlint >/dev/null; then\nswiftlint\nelse\necho \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
 		};
 		125DD8FE22F0C5C400AFA88B /* Carthage Copy-Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -1337,7 +1337,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "/usr/local/bin/carthage copy-frameworks\n";
+			shellScript = "/opt/homebrew/bin/carthage copy-frameworks\n";
 		};
 		125DD90022F0C77800AFA88B /* Carthage Copy-Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -1357,7 +1357,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "/usr/local/bin/carthage copy-frameworks\n";
+			shellScript = "/opt/homebrew/bin/carthage copy-frameworks\n";
 		};
 		125DD90122F0C89600AFA88B /* Carthage Copy-Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -1377,7 +1377,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "/usr/local/bin/carthage copy-frameworks\n";
+			shellScript = "/opt/homebrew/bin/carthage copy-frameworks\n";
 		};
 		125DD90E22F0E49900AFA88B /* Carthage Copy-Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -1397,7 +1397,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "/usr/local/bin/carthage copy-frameworks\n";
+			shellScript = "/opt/homebrew/bin/carthage copy-frameworks\n";
 		};
 		125DD91022F0E4EF00AFA88B /* Carthage Copy-Framework */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -1417,7 +1417,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "/usr/local/bin/carthage copy-frameworks\n";
+			shellScript = "/opt/homebrew/bin/carthage copy-frameworks\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -1725,7 +1725,7 @@
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 4;
-				WATCHOS_DEPLOYMENT_TARGET = 4.2;
+				WATCHOS_DEPLOYMENT_TARGET = 6.0;
 			};
 			name = Debug;
 		};
@@ -1746,7 +1746,7 @@
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 4;
-				WATCHOS_DEPLOYMENT_TARGET = 4.2;
+				WATCHOS_DEPLOYMENT_TARGET = 6.0;
 			};
 			name = Release;
 		};
@@ -1767,7 +1767,7 @@
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = 4;
-				WATCHOS_DEPLOYMENT_TARGET = 4.2;
+				WATCHOS_DEPLOYMENT_TARGET = 6.0;
 			};
 			name = Debug;
 		};
@@ -1788,7 +1788,7 @@
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = 4;
-				WATCHOS_DEPLOYMENT_TARGET = 4.2;
+				WATCHOS_DEPLOYMENT_TARGET = 6.0;
 			};
 			name = Release;
 		};
@@ -1817,6 +1817,7 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
@@ -1843,7 +1844,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -1880,6 +1881,7 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
@@ -1900,7 +1902,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
@@ -1979,7 +1981,7 @@
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
 				);
 				INFOPLIST_FILE = "Tests/Supporting Files/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2001,7 +2003,7 @@
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
 				);
 				INFOPLIST_FILE = "Tests/Supporting Files/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2041,7 +2043,7 @@
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 4;
-				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+				WATCHOS_DEPLOYMENT_TARGET = 6.0;
 			};
 			name = Debug;
 		};
@@ -2072,7 +2074,7 @@
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 4;
-				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+				WATCHOS_DEPLOYMENT_TARGET = 6.0;
 			};
 			name = Release;
 		};
@@ -2103,7 +2105,7 @@
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 3;
-				TVOS_DEPLOYMENT_TARGET = 9.0;
+				TVOS_DEPLOYMENT_TARGET = 12.0;
 			};
 			name = Debug;
 		};
@@ -2134,7 +2136,7 @@
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 3;
-				TVOS_DEPLOYMENT_TARGET = 9.0;
+				TVOS_DEPLOYMENT_TARGET = 12.0;
 			};
 			name = Release;
 		};
@@ -2158,7 +2160,7 @@
 				SDKROOT = appletvos;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 3;
-				TVOS_DEPLOYMENT_TARGET = 11.2;
+				TVOS_DEPLOYMENT_TARGET = 12.0;
 			};
 			name = Debug;
 		};
@@ -2182,7 +2184,7 @@
 				SDKROOT = appletvos;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 3;
-				TVOS_DEPLOYMENT_TARGET = 11.2;
+				TVOS_DEPLOYMENT_TARGET = 12.0;
 			};
 			name = Release;
 		};
@@ -2193,7 +2195,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = "$(SRCROOT)/Examples/Hyperspace-iOSExample/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2212,7 +2214,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = "$(SRCROOT)/Examples/Hyperspace-iOSExample/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2241,7 +2243,7 @@
 				SDKROOT = appletvos;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 3;
-				TVOS_DEPLOYMENT_TARGET = 11.2;
+				TVOS_DEPLOYMENT_TARGET = 12.0;
 			};
 			name = Debug;
 		};
@@ -2262,7 +2264,7 @@
 				SDKROOT = appletvos;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 3;
-				TVOS_DEPLOYMENT_TARGET = 11.2;
+				TVOS_DEPLOYMENT_TARGET = 12.0;
 			};
 			name = Release;
 		};

--- a/Hyperspace.xcodeproj/project.pbxproj
+++ b/Hyperspace.xcodeproj/project.pbxproj
@@ -182,6 +182,8 @@
 		65709A27272E0B9D0066361E /* BackendService+Async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65709A26272E0B9D0066361E /* BackendService+Async.swift */; };
 		65709A2A272E0F8E0066361E /* AsyncTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65709A28272E0F600066361E /* AsyncTests.swift */; };
 		65709A2B272E0F8F0066361E /* AsyncTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65709A28272E0F600066361E /* AsyncTests.swift */; };
+		65A672F62731991A000E3511 /* TestDecodingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65A672F52731991A000E3511 /* TestDecodingError.swift */; };
+		65A672F72731991A000E3511 /* TestDecodingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65A672F52731991A000E3511 /* TestDecodingError.swift */; };
 		B4255B59246E528C009B6D6A /* EncodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4255B57246E525F009B6D6A /* EncodingTests.swift */; };
 		B4255B5A246E528D009B6D6A /* EncodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4255B57246E525F009B6D6A /* EncodingTests.swift */; };
 		B469328F2413539700D2B650 /* TransportResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = B469328E2413539700D2B650 /* TransportResult.swift */; };
@@ -450,6 +452,7 @@
 		60EB8FDB1FF59FB000AC0B55 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		65709A26272E0B9D0066361E /* BackendService+Async.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BackendService+Async.swift"; sourceTree = "<group>"; };
 		65709A28272E0F600066361E /* AsyncTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncTests.swift; sourceTree = "<group>"; };
+		65A672F52731991A000E3511 /* TestDecodingError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestDecodingError.swift; sourceTree = "<group>"; };
 		B4255B57246E525F009B6D6A /* EncodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EncodingTests.swift; sourceTree = "<group>"; };
 		B469328E2413539700D2B650 /* TransportResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransportResult.swift; sourceTree = "<group>"; };
 		B476477424136071003C97E9 /* Request.URLRequestCreationStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Request.URLRequestCreationStrategy.swift; sourceTree = "<group>"; };
@@ -812,6 +815,7 @@
 			isa = PBXGroup;
 			children = (
 				30F0735F202213E00045CB01 /* RequestTestDefaults.swift */,
+				65A672F52731991A000E3511 /* TestDecodingError.swift */,
 			);
 			path = "Test Defaults";
 			sourceTree = "<group>";
@@ -1502,6 +1506,7 @@
 				30F0735420210A890045CB01 /* HTTPTests.swift in Sources */,
 				3026E459202008720003A321 /* TransportSessionTest.swift in Sources */,
 				CB0961EC21E531A3006CC9F5 /* FutureTests.swift in Sources */,
+				65A672F62731991A000E3511 /* TestDecodingError.swift in Sources */,
 				60D6C40B201CFCCF00B3B012 /* MockCodableContainer.swift in Sources */,
 				0EF57B7D2202745800484C01 /* PinningTests.swift in Sources */,
 				60D6C407201CFCCF00B3B012 /* MockNetworkSessionDataTask.swift in Sources */,
@@ -1605,6 +1610,7 @@
 				30F0735520210A8B0045CB01 /* HTTPTests.swift in Sources */,
 				3026E45A2020087C0003A321 /* TransportSessionTest.swift in Sources */,
 				CB0961ED21E531A4006CC9F5 /* FutureTests.swift in Sources */,
+				65A672F72731991A000E3511 /* TestDecodingError.swift in Sources */,
 				60D6C40C201CFCCF00B3B012 /* MockCodableContainer.swift in Sources */,
 				0EF57B7E2202745800484C01 /* PinningTests.swift in Sources */,
 				60D6C408201CFCCF00B3B012 /* MockNetworkSessionDataTask.swift in Sources */,

--- a/Hyperspace.xcodeproj/project.pbxproj
+++ b/Hyperspace.xcodeproj/project.pbxproj
@@ -180,6 +180,8 @@
 		60D6C443201D188B00B3B012 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 60D6C441201D188B00B3B012 /* Main.storyboard */; };
 		60D6C445201D188B00B3B012 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 60D6C444201D188B00B3B012 /* Assets.xcassets */; };
 		65709A27272E0B9D0066361E /* BackendService+Async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65709A26272E0B9D0066361E /* BackendService+Async.swift */; };
+		65709A2A272E0F8E0066361E /* AsyncTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65709A28272E0F600066361E /* AsyncTests.swift */; };
+		65709A2B272E0F8F0066361E /* AsyncTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65709A28272E0F600066361E /* AsyncTests.swift */; };
 		B4255B59246E528C009B6D6A /* EncodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4255B57246E525F009B6D6A /* EncodingTests.swift */; };
 		B4255B5A246E528D009B6D6A /* EncodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4255B57246E525F009B6D6A /* EncodingTests.swift */; };
 		B469328F2413539700D2B650 /* TransportResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = B469328E2413539700D2B650 /* TransportResult.swift */; };
@@ -447,6 +449,7 @@
 		60D6C446201D188B00B3B012 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		60EB8FDB1FF59FB000AC0B55 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		65709A26272E0B9D0066361E /* BackendService+Async.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BackendService+Async.swift"; sourceTree = "<group>"; };
+		65709A28272E0F600066361E /* AsyncTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncTests.swift; sourceTree = "<group>"; };
 		B4255B57246E525F009B6D6A /* EncodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EncodingTests.swift; sourceTree = "<group>"; };
 		B469328E2413539700D2B650 /* TransportResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransportResult.swift; sourceTree = "<group>"; };
 		B476477424136071003C97E9 /* Request.URLRequestCreationStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Request.URLRequestCreationStrategy.swift; sourceTree = "<group>"; };
@@ -669,25 +672,26 @@
 		60AC831F1FF58E8B00120172 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
-				0EF57B852202967900484C01 /* Certificates */,
-				60D6C3F0201CFCCF00B3B012 /* BackendServiceTests.swift */,
+				65709A28272E0F600066361E /* AsyncTests.swift */,
 				0EBF9B1C246F347800E990DC /* AnyErrorTests.swift */,
-				0E81B49A20AC97C900DC1F4E /* RecoverableTests.swift */,
-				60D6C3F1201CFCCF00B3B012 /* DecodingTests.swift */,
-				B4255B57246E525F009B6D6A /* EncodingTests.swift */,
+				60D6C3F0201CFCCF00B3B012 /* BackendServiceTests.swift */,
+				0EF57B87220296A700484C01 /* CertificateHashTests.swift */,
 				0E29092B21349F320031F67C /* DecodingFailureTests.swift */,
-				CB0961EA21E5317B006CC9F5 /* FutureTests.swift */,
-				60D6C3F7201CFCCF00B3B012 /* RequestTests.swift */,
-				60D6C3EF201CFCCF00B3B012 /* TransportServiceTests.swift */,
+				60D6C3F1201CFCCF00B3B012 /* DecodingTests.swift */,
 				0E458C8924EDC7FE00DC3E70 /* EmptyDecodingStrategyTests.swift */,
-				3026E457202008470003A321 /* TransportSessionTest.swift */,
-				0E458C8424EDAEF700DC3E70 /* TransportResultTests.swift */,
+				B4255B57246E525F009B6D6A /* EncodingTests.swift */,
+				0EBEC09324EC66D700C37ADA /* FormURLEncoderTests.swift */,
+				CB0961EA21E5317B006CC9F5 /* FutureTests.swift */,
 				30F07352202109F60045CB01 /* HTTPTests.swift */,
 				B4C32C32201E9F9300FC82C1 /* NetworkActivityIndicatorTests.swift */,
-				0ECDC1C220A9ED6700ABF991 /* URLQueryParameterTests.swift */,
-				0EBEC09324EC66D700C37ADA /* FormURLEncoderTests.swift */,
 				0EF57B7C2202745800484C01 /* PinningTests.swift */,
-				0EF57B87220296A700484C01 /* CertificateHashTests.swift */,
+				0E81B49A20AC97C900DC1F4E /* RecoverableTests.swift */,
+				60D6C3F7201CFCCF00B3B012 /* RequestTests.swift */,
+				0E458C8424EDAEF700DC3E70 /* TransportResultTests.swift */,
+				60D6C3EF201CFCCF00B3B012 /* TransportServiceTests.swift */,
+				3026E457202008470003A321 /* TransportSessionTest.swift */,
+				0ECDC1C220A9ED6700ABF991 /* URLQueryParameterTests.swift */,
+				0EF57B852202967900484C01 /* Certificates */,
 				60D6C419201CFCE500B3B012 /* Helper */,
 				60EB8FDA1FF59FB000AC0B55 /* Supporting Files */,
 			);
@@ -1491,6 +1495,7 @@
 				0E347E6521599B7F00BF18FA /* XCTestCase+JSON.swift in Sources */,
 				30F07361202213E50045CB01 /* RequestTestDefaults.swift in Sources */,
 				0ECDC1C420A9EDA500ABF991 /* URLQueryParameterTests.swift in Sources */,
+				65709A2A272E0F8E0066361E /* AsyncTests.swift in Sources */,
 				B4255B59246E528C009B6D6A /* EncodingTests.swift in Sources */,
 				60D6C40D201CFCCF00B3B012 /* RequestTests.swift in Sources */,
 				0E458C8C24EDCC3500DC3E70 /* EmptyDecodingStrategyTests.swift in Sources */,
@@ -1593,6 +1598,7 @@
 				0E347E6421599B7D00BF18FA /* XCTestCase+JSON.swift in Sources */,
 				30F07362202213E60045CB01 /* RequestTestDefaults.swift in Sources */,
 				0ECDC1C520A9EDA600ABF991 /* URLQueryParameterTests.swift in Sources */,
+				65709A2B272E0F8F0066361E /* AsyncTests.swift in Sources */,
 				B4255B5A246E528D009B6D6A /* EncodingTests.swift in Sources */,
 				60D6C40E201CFCCF00B3B012 /* RequestTests.swift in Sources */,
 				0E458C8D24EDCC3700DC3E70 /* EmptyDecodingStrategyTests.swift in Sources */,
@@ -2003,6 +2009,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_WORKSPACE = YES;
 			};
 			name = Debug;
 		};
@@ -2025,6 +2032,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_WORKSPACE = YES;
 			};
 			name = Release;
 		};
@@ -2173,6 +2181,7 @@
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 12.0;
+				VALIDATE_WORKSPACE = YES;
 			};
 			name = Debug;
 		};
@@ -2197,6 +2206,7 @@
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 12.0;
+				VALIDATE_WORKSPACE = YES;
 			};
 			name = Release;
 		};

--- a/Hyperspace.xcodeproj/xcshareddata/xcschemes/Hyperspace_iOS.xcscheme
+++ b/Hyperspace.xcodeproj/xcshareddata/xcschemes/Hyperspace_iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1000"
+   LastUpgradeVersion = "1310"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,8 +26,17 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      codeCoverageEnabled = "YES"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "60AC82B51FF588D500120172"
+            BuildableName = "Hyperspace.framework"
+            BlueprintName = "Hyperspace-iOS"
+            ReferencedContainer = "container:Hyperspace.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -44,17 +53,6 @@
             </LocationScenarioReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "60AC82B51FF588D500120172"
-            BuildableName = "Hyperspace.framework"
-            BlueprintName = "Hyperspace-iOS"
-            ReferencedContainer = "container:Hyperspace.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -75,8 +73,6 @@
             ReferencedContainer = "container:Hyperspace.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Hyperspace.xcodeproj/xcshareddata/xcschemes/Hyperspace_tvOS.xcscheme
+++ b/Hyperspace.xcodeproj/xcshareddata/xcschemes/Hyperspace_tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1000"
+   LastUpgradeVersion = "1310"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,8 +26,17 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      codeCoverageEnabled = "YES"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "60AC82E11FF589C200120172"
+            BuildableName = "Hyperspace.framework"
+            BlueprintName = "Hyperspace-tvOS"
+            ReferencedContainer = "container:Hyperspace.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -40,17 +49,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "60AC82E11FF589C200120172"
-            BuildableName = "Hyperspace.framework"
-            BlueprintName = "Hyperspace-tvOS"
-            ReferencedContainer = "container:Hyperspace.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -71,8 +69,6 @@
             ReferencedContainer = "container:Hyperspace.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Hyperspace.xcodeproj/xcshareddata/xcschemes/Hyperspace_watchOS.xcscheme
+++ b/Hyperspace.xcodeproj/xcshareddata/xcschemes/Hyperspace_watchOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1000"
+   LastUpgradeVersion = "1310"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -29,8 +29,6 @@
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -51,8 +49,6 @@
             ReferencedContainer = "container:Hyperspace.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Package.swift
+++ b/Package.swift
@@ -4,10 +4,10 @@ import PackageDescription
 let package = Package(
     name: "Hyperspace",
     platforms: [
-        .macOS("10.12"),
-        .iOS("10.0"),
-        .tvOS("10.0"),
-        .watchOS("4.2")
+        .macOS("10.15"),
+        .iOS("12.0"),
+        .tvOS("12.0"),
+        .watchOS("6.0")
     ],
     products: [
         .library(

--- a/Sources/Async/BackendService+Async.swift
+++ b/Sources/Async/BackendService+Async.swift
@@ -1,0 +1,29 @@
+//
+//  BackendService+Async.swift
+//  Hyperspace-iOS
+//
+//  Created by Daniel Larsen on 10/30/21.
+//  Copyright © 2021 Bottle Rocket Studios. All rights reserved.
+//
+
+import Foundation
+
+extension BackendServiceProtocol {
+
+    /// Executes the Request, returning the specified value type. Throws an error if unable to return the value as specified.
+    ///
+    /// - Parameters:
+    ///   - request: The Request to be executed.
+    /// - Returns: The decodable type specified in the `Request`.
+    @available(iOSApplicationExtension 13.0.0, *)
+    public func execute<T, U>(request: Request<T, U>) async throws -> T {
+        return try await withCheckedThrowingContinuation { continuation in
+            execute(request: request) { result in
+                switch result {
+                case .success(let value): continuation.resume(returning: value)
+                case .failure(let err): continuation.resume(throwing: err)
+                }
+            }
+        }
+    }
+}

--- a/Sources/Async/BackendService+Async.swift
+++ b/Sources/Async/BackendService+Async.swift
@@ -8,20 +8,36 @@
 
 import Foundation
 
+@available(iOS 13.0, *)
 extension BackendServiceProtocol {
 
-    /// Executes the Request, returning the specified value type. Throws an error if unable to return the value as specified.
+    /// Executes the Request asynchronously, returning the specified value type. Throws an error if unable to return the value as specified.
     ///
     /// - Parameters:
     ///   - request: The Request to be executed.
     /// - Returns: The decodable type specified in the `Request`.
-    @available(iOSApplicationExtension 13.0.0, *)
     public func execute<T, U>(request: Request<T, U>) async throws -> T {
         return try await withCheckedThrowingContinuation { continuation in
             execute(request: request) { result in
                 switch result {
                 case .success(let value): continuation.resume(returning: value)
                 case .failure(let err): continuation.resume(throwing: err)
+                }
+            }
+        }
+    }
+
+    /// Executes the Request asynchronously without throwing any errors
+    ///
+    /// - Parameters:
+    ///   - request: The Request to be executed.
+    /// - Returns: A `Result` of given value type `T` and error type `U`.
+    public func executeWithResult<T, U>(request: Request<T, U>) async -> Result<T, U> {
+        return await withCheckedContinuation { continuation in
+            execute(request: request) { result in
+                switch result {
+                case .success(let value): continuation.resume(with: .success(Result<T, U>.success(value)))
+                case .failure(let err): continuation.resume(with: .success(Result<T, U>.failure(err)))
                 }
             }
         }

--- a/Sources/Async/BackendService+Async.swift
+++ b/Sources/Async/BackendService+Async.swift
@@ -17,13 +17,11 @@ extension BackendServiceProtocol {
     ///   - request: The Request to be executed.
     /// - Returns: The decodable type specified in the `Request`.
     public func execute<T, U>(request: Request<T, U>) async throws -> T {
-        return try await withCheckedThrowingContinuation { continuation in
-            execute(request: request) { result in
-                switch result {
-                case .success(let value): continuation.resume(returning: value)
-                case .failure(let err): continuation.resume(throwing: err)
-                }
-            }
+        let result = await executeWithResult(request: request)
+
+        switch result {
+        case .success(let value): return value
+        case .failure(let err): throw err
         }
     }
 

--- a/Sources/Certificate Pinning/CertificateHasher.swift
+++ b/Sources/Certificate Pinning/CertificateHasher.swift
@@ -13,9 +13,9 @@ import CommonCrypto
 struct CertificateHasher {
     
     enum Error: Swift.Error {
-        case contextError //There was an issue performing the cryptographic operations to retrieve the pinning hash
-        case unableToRetrievePublicKey //There was an issue extracting the public key from the certificate
-        case unsupportedAlgorithm //The public key is utilizing an unsupporting algorithm. RSA2048, RSA4096, ECSECPrimeRandom256 and ECSECPrimeRandom384 are supported
+        case contextError // There was an issue performing the cryptographic operations to retrieve the pinning hash
+        case unableToRetrievePublicKey // There was an issue extracting the public key from the certificate
+        case unsupportedAlgorithm // The public key is utilizing an unsupporting algorithm. RSA2048, RSA4096, ECSECPrimeRandom256 and ECSECPrimeRandom384 are supported
     }
     
     enum PublicKeyAlgorithm: String {
@@ -92,11 +92,11 @@ private extension CertificateHasher {
         var shaCtx = CC_SHA256_CTX()
         CC_SHA256_Init(&shaCtx)
         
-        //Add the missing ASN1 header
+        // Add the missing ASN1 header
         guard let algorithm = PublicKeyAlgorithm(keyType: publicKey.type, keySize: publicKey.size) else { throw Error.unsupportedAlgorithm }
         let header = algorithm.asn1HeaderBytes
 
-        //Add the appropriate header and public key
+        // Add the appropriate header and public key
         CC_SHA256_Update(&shaCtx, header, CC_LONG(header.count))
         CC_SHA256_Update(&shaCtx, keyData.bytes, CC_LONG(keyData.length))
         

--- a/Sources/Certificate Pinning/CertificateHasher.swift
+++ b/Sources/Certificate Pinning/CertificateHasher.swift
@@ -53,10 +53,10 @@ struct CertificateHasher {
     }
     
     static func checkValidity(of trust: SecTrust) -> Bool {
-        var result = SecTrustResultType.invalid
-        let status = SecTrustEvaluate(trust, &result)
+        var result: CFError?
+        let status = SecTrustEvaluateWithError(trust, &result)
         
-        return (status == errSecSuccess) ? (result == .unspecified || result == .proceed) : false
+        return status || result == nil
     }
 }
 

--- a/Sources/Certificate Pinning/TrustValidatingTransportService.swift
+++ b/Sources/Certificate Pinning/TrustValidatingTransportService.swift
@@ -30,12 +30,12 @@ public class TrustValidatingTransportService: Transporting {
             let validator = TrustValidator(configuration: configuration)
             
             guard validator.canHandle(challenge: challenge) else {
-                //This was NOT a server trust authentication challenge - further input is required
+                // This was NOT a server trust authentication challenge - further input is required
                 return completionHandler(.performDefaultHandling, nil)
             }
             
             validator.handle(challenge: challenge, handler: completionHandler)
-            //The server trust authentication challenge was handled (for both allow and blocks) - not further input is required
+            // The server trust authentication challenge was handled (for both allow and blocks) - not further input is required
         }
     }
 

--- a/Sources/Certificate Pinning/TrustValidator.swift
+++ b/Sources/Certificate Pinning/TrustValidator.swift
@@ -48,7 +48,7 @@ public class TrustValidator {
     ///   - handler: The handler to be called when the challenge is a 'server trust' authentication challenge. For all other types of authentication challenge, this handler will NOT be called.
     public func handle(challenge: AuthenticationChallenge, handler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
         guard canHandle(challenge: challenge), let serverTrust = challenge.serverTrust else {
-            return //The challenge was not a server trust evaluation, and so left unhandled
+            return // The challenge was not a server trust evaluation, and so left unhandled
         }
         
         switch evaluate(serverTrust, forHost: challenge.host) {
@@ -60,22 +60,22 @@ public class TrustValidator {
     
     func evaluate(_ trust: SecTrust, forHost host: String, date: Date = Date()) -> Decision {
         guard let domainConfig = configuration.domainConfiguration(forHost: host), domainConfig.shouldValidateCertificate(forHost: host, at: date) else {
-            return .notPinned //We are either not able to retrieve the certificate from the trust or we are not configured to pin this domain
+            return .notPinned // We are either not able to retrieve the certificate from the trust or we are not configured to pin this domain
         }
         
-        //Set an SSL policy and evaluate the trust
+        // Set an SSL policy and evaluate the trust
         let policies = NSArray(array: [SecPolicyCreateSSL(true, nil)])
         SecTrustSetPolicies(trust, policies)
         
         guard trust.isValid else { return .block }
         
-        //If the server trust evaluation is successful, walk the certificate chain
+        // If the server trust evaluation is successful, walk the certificate chain
         let certificateCount = SecTrustGetCertificateCount(trust)
         for certIndex in 0..<certificateCount {
             guard let certificate = SecTrustGetCertificateAtIndex(trust, certIndex) else { continue }
             
             if domainConfig.validate(against: certificate) {
-                //Found a pinned certificate, allow the connection
+                // Found a pinned certificate, allow the connection
                 return .allow(URLCredential(trust: trust))
             }
         }

--- a/Sources/Hyperspace/HTTP/HTTP.swift
+++ b/Sources/Hyperspace/HTTP/HTTP.swift
@@ -133,7 +133,7 @@ public struct HTTP {
         /// The raw body data to be attached to the HTTP request
         public let data: Data?
         public let additionalHeaders: [HeaderKey: HeaderValue]
-        
+
         /// Initializes a new `HTTP.Body` instance given the raw `Data` to be attached.
         /// - Parameters:
         ///   - data: The raw `Data` to set as the HTTP body.

--- a/Sources/Hyperspace/Service/Peripheral/NetworkActivityIndicatable.swift
+++ b/Sources/Hyperspace/Service/Peripheral/NetworkActivityIndicatable.swift
@@ -74,7 +74,7 @@ private extension NetworkActivityController {
         delayedHide = nil
 
         DispatchQueue.main.async {
-            //Only need to set the visibility of the indicator if it has changed
+            // Only need to set the visibility of the indicator if it has changed
             if self.indicator.isNetworkActivityIndicatorVisible != visible {
                 self.indicator.isNetworkActivityIndicatorVisible = visible
             }

--- a/Tests/AsyncTests.swift
+++ b/Tests/AsyncTests.swift
@@ -75,10 +75,10 @@ class AsyncTests: XCTestCase {
     }
 
     private func executeBackendService<T: Equatable, U: Equatable>(mockRequest: Request<T, U>,
-                                             mockedTransportResult: TransportResult,
-                                             expectingResult expectedResult: Result<T, U>,
-                                             file: StaticString = #file,
-                                             line: UInt = #line) async {
+                                                                   mockedTransportResult: TransportResult,
+                                                                   expectingResult expectedResult: Result<T, U>,
+                                                                   file: StaticString = #file,
+                                                                   line: UInt = #line) async {
         let mockTransportService = MockTransportService(responseResult: mockedTransportResult)
         let backendService = BackendService(transportService: mockTransportService)
 

--- a/Tests/AsyncTests.swift
+++ b/Tests/AsyncTests.swift
@@ -19,17 +19,37 @@ class AsyncTests: XCTestCase {
     private let defaultModelJSONData = RequestTestDefaults.defaultModelJSONData
     private let defaultRequest: Request<DefaultModel, MockBackendServiceError> = RequestTestDefaults.defaultRequest()
     private var defaultHTTPRequest: HTTP.Request { HTTP.Request(urlRequest: defaultRequest.urlRequest) }
+    private let analyticsRequest: Request<DefaultModel, MockAnalyticsServiceError> = RequestTestDefaults.analyticsRequest()
 
     // MARK: - Tests
     func test_FailingRequestAlsoThrows() async {
         let failure = TransportFailure(error: TransportError(code: .noInternetConnection),
-                                       request: defaultHTTPRequest, response: nil)
-        do {
-            _ = try await executeBackendRequest(expectedResult: .failure(failure))
-            XCTFail("Expected to throw while awaiting, but succeeded")
-        } catch {
-            XCTAssertEqual(error as? MockBackendServiceError, .networkError(TransportError(code: .noInternetConnection), nil))
-        }
+                                       request: defaultHTTPRequest,
+                                       response: nil)
+        let error = await evaluateThrowingRequest(failure)
+        XCTAssertNil(error)
+    }
+
+    func test_FailingRequestThrowsDifferentError() async {
+        let failure = TransportFailure(error: TransportError(clientError: TestDecodingError.keyNotFound),
+                                       request: defaultHTTPRequest,
+                                       response: nil)
+        let error = await evaluateThrowingRequest(failure) as? TestDecodingError
+        XCTAssertEqual(error, TestDecodingError.keyNotFound)
+    }
+
+    func test_FailingBackendRequest() async {
+        let backendFailure = TransportFailure(error: TransportError(code: .noInternetConnection),
+                                              request: defaultHTTPRequest,
+                                              response: nil)
+
+        await executeBackendService(mockRequest: defaultRequest,
+                                    mockedTransportResult: TransportResult(error: backendFailure),
+                                    expectingResult: .failure(MockBackendServiceError(transportFailure: backendFailure)))
+
+        await executeBackendService(mockRequest: analyticsRequest,
+                                    mockedTransportResult: TransportResult(error: backendFailure),
+                                    expectingResult: .failure(MockAnalyticsServiceError(transportFailure: backendFailure)))
     }
 
     func test_SuccessfulResultAlsoSucceeds() async throws {
@@ -42,7 +62,43 @@ class AsyncTests: XCTestCase {
     }
 
     // MARK: - Private Helpers
-    private func executeBackendRequest(expectedResult: TransportResult, file: StaticString = #file, line: UInt = #line) async throws -> DefaultModel {
+    fileprivate func evaluateThrowingRequest(_ failure: TransportFailure) async -> Error? {
+        do {
+            _ = try await executeBackendRequest(expectedResult: .failure(failure))
+            XCTFail("Expected to throw while awaiting, but succeeded")
+        } catch {
+            let backendError = error as? MockBackendServiceError
+            return backendError?.transportError?.underlyingError
+        }
+
+        return nil
+    }
+
+    private func executeBackendService<T: Equatable, U: Equatable>(mockRequest: Request<T, U>,
+                                             mockedTransportResult: TransportResult,
+                                             expectingResult expectedResult: Result<T, U>,
+                                             file: StaticString = #file,
+                                             line: UInt = #line) async {
+        let mockTransportService = MockTransportService(responseResult: mockedTransportResult)
+        let backendService = BackendService(transportService: mockTransportService)
+
+        let result = await backendService.executeWithResult(request: mockRequest)
+
+        switch (result, expectedResult) {
+        case (.success(let resultObject), .success(let expectedObject)):
+            XCTAssertEqual(resultObject, expectedObject, file: file, line: line)
+        case (.failure(let resultError), .failure(let expectedError)):
+            XCTAssertEqual(resultError, expectedError, file: file, line: line)
+        default:
+            XCTFail("Result '\(result)' not equal to expected result '\(expectedResult)'", file: file, line: line)
+        }
+
+        XCTAssertEqual(mockTransportService.lastExecutedURLRequest, mockRequest.urlRequest, file: file, line: line)
+    }
+
+    private func executeBackendRequest(expectedResult: TransportResult,
+                                       file: StaticString = #file,
+                                       line: UInt = #line) async throws -> DefaultModel {
         let transportService = MockTransportService(responseResult: expectedResult)
         let backendService = BackendService(transportService: transportService)
 

--- a/Tests/AsyncTests.swift
+++ b/Tests/AsyncTests.swift
@@ -1,0 +1,51 @@
+//
+//  AsyncTests.swift
+//  Hyperspace-iOS
+//
+//  Created by Daniel Larsen on 10/30/21.
+//  Copyright © 2021 Bottle Rocket Studios. All rights reserved.
+//
+
+import Hyperspace
+import XCTest
+
+@available(iOS 13.0.0, *)
+class AsyncTests: XCTestCase {
+
+    // MARK: - Type Aliases
+    typealias DefaultModel = RequestTestDefaults.DefaultModel
+
+    // MARK: - Properties
+    private let defaultModelJSONData = RequestTestDefaults.defaultModelJSONData
+    private let defaultRequest: Request<DefaultModel, MockBackendServiceError> = RequestTestDefaults.defaultRequest()
+    private var defaultHTTPRequest: HTTP.Request { HTTP.Request(urlRequest: defaultRequest.urlRequest) }
+
+    // MARK: - Tests
+    func test_FailingRequestAlsoThrows() async {
+        let failure = TransportFailure(error: TransportError(code: .noInternetConnection),
+                                       request: defaultHTTPRequest, response: nil)
+        do {
+            _ = try await executeBackendRequest(expectedResult: .failure(failure))
+            XCTFail("Expected to throw while awaiting, but succeeded")
+        } catch {
+            XCTAssertEqual(error as? MockBackendServiceError, .networkError(TransportError(code: .noInternetConnection), nil))
+        }
+    }
+
+    func test_SuccessfulResultAlsoSucceeds() async throws {
+        let success = TransportSuccess(response: HTTP.Response(request: defaultHTTPRequest,
+                                                               code: 200,
+                                                               body: defaultModelJSONData))
+
+        let result = try await executeBackendRequest(expectedResult: .success(success))
+        XCTAssert(result.title == "test")
+    }
+
+    // MARK: - Private Helpers
+    private func executeBackendRequest(expectedResult: TransportResult, file: StaticString = #file, line: UInt = #line) async throws -> DefaultModel {
+        let transportService = MockTransportService(responseResult: expectedResult)
+        let backendService = BackendService(transportService: transportService)
+
+        return try await backendService.execute(request: defaultRequest)
+    }
+}

--- a/Tests/DecodingTests.swift
+++ b/Tests/DecodingTests.swift
@@ -160,6 +160,6 @@ class DecodingTests: XCTestCase {
         let objectJSON = loadedJSONData(fromFileNamed: "RootKeyArray")
         let serviceSuccess = TransportSuccess(response: HTTP.Response(request: HTTP.Request(), code: 200, body: objectJSON))
         let result = request.transform(success: serviceSuccess)
-        XCTAssertNil(result.value) //Should fail because RootKeyArray json contains [MockObject], not a single MockObject
+        XCTAssertNil(result.value) // Should fail because RootKeyArray json contains [MockObject], not a single MockObject
     }
 }

--- a/Tests/Helper/Mocks/MockBackendService.swift
+++ b/Tests/Helper/Mocks/MockBackendService.swift
@@ -52,7 +52,6 @@ extension MockBackendServiceError: Equatable {
 
 public enum MockAnalyticsServiceError: TransportFailureRepresentable, DecodingFailureRepresentable {
 
-
     case networkError(TransportError, HTTP.Response?)
     case dataTransformationError(Error)
 

--- a/Tests/Helper/Test Defaults/RequestTestDefaults.swift
+++ b/Tests/Helper/Test Defaults/RequestTestDefaults.swift
@@ -18,7 +18,11 @@ class RequestTestDefaults {
     static func defaultRequest<T: Decodable>() -> Request<T, MockBackendServiceError> {
         return Request(method: .get, url: RequestTestDefaults.defaultURL, cachePolicy: RequestTestDefaults.defaultCachePolicy, timeout: RequestTestDefaults.defaultTimeout)
     }
-    
+
+    static func analyticsRequest<T: Decodable>() -> Request<T, MockAnalyticsServiceError> {
+        return Request(method: .get, url: RequestTestDefaults.defaultURL, cachePolicy: RequestTestDefaults.defaultCachePolicy, timeout: RequestTestDefaults.defaultTimeout)
+    }
+
     static let defaultModel = DefaultModel(title: "test")
     static let defaultModelJSONData: Data = {
         let jsonEncoder = JSONEncoder()

--- a/Tests/Helper/Test Defaults/TestDecodingError.swift
+++ b/Tests/Helper/Test Defaults/TestDecodingError.swift
@@ -1,0 +1,15 @@
+//
+//  TestDecodingError.swift
+//  Hyperspace
+//
+//  Created by Daniel Larsen on 10/31/21.
+//  Copyright © 2021 Bottle Rocket Studios. All rights reserved.
+//
+
+import Foundation
+
+enum TestDecodingError: Error, Equatable {
+
+    case keyNotFound
+    case invalidValue
+}


### PR DESCRIPTION
Y'all do these comments long, but I'm not so sure about that. Anyway, here's what I did:

- Added in an extension to `BackendServiceProtocol` to shim in an `async` function.
- Added unit tests for said `async` shim.
- Updated Xcode project to work with Xcode 12 and later.
- Updated Carthage to get project to compile (per instructions in `README.md`)
- Updated platform target for watchOS to watchOS 6 (necessary to get project compiling)

Some things I'd like to do either in this PR or in a future PR:

- Get sample `async` calls in playground and example project
- Rework project structure around SPM authoring
- Make `async` calls a bit more native to the framework once supported by the Foundation framework. That means removing the `async withCheckedThrowingContinuation` block and adding in `async` versions of the execute function to the transport and backend layers.
