### PR TITLE
Feature/async await refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 #### Enhancements
 
+* Renamed async execution function `executeAsync` to avoid namespace collision with futures-based execution.
+[Daniel Larsen](https://github.com/grandlarseny)
+[#142]https://github.com/BottleRocketStudios/iOS-Hyperspace/pull/143
+
 * Added async / await functions for executing requests
 [Daniel Larsen](https://github.com/grandlarseny)
 [#142]https://github.com/BottleRocketStudios/iOS-Hyperspace/pull/142

--- a/Sources/Async/BackendService+Async.swift
+++ b/Sources/Async/BackendService+Async.swift
@@ -16,7 +16,7 @@ extension BackendServiceProtocol {
     /// - Parameters:
     ///   - request: The Request to be executed.
     /// - Returns: The decodable type specified in the `Request`.
-    public func execute<T, U>(request: Request<T, U>) async throws -> T {
+    public func executeAsync<T, U>(request: Request<T, U>) async throws -> T {
         let result = await executeWithResult(request: request)
 
         switch result {

--- a/Tests/AsyncTests.swift
+++ b/Tests/AsyncTests.swift
@@ -102,6 +102,6 @@ class AsyncTests: XCTestCase {
         let transportService = MockTransportService(responseResult: expectedResult)
         let backendService = BackendService(transportService: transportService)
 
-        return try await backendService.execute(request: defaultRequest)
+        return try await backendService.executeAsync(request: defaultRequest)
     }
 }


### PR DESCRIPTION
I was having problems using the async functions in a project. Seems like it might be a namespace collision with the futures-based execution function.