### PR TITLE
Build out PreparationStrategy functionality

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -5,6 +5,12 @@ disabled_rules:
   - trailing_whitespace # Disables SwiftLint complaining about whitespace characters on empty lines
   - todo # Disables auto-warning of TODO statements
 
+nesting:
+  type_level:
+    warning: 2
+  function_level:
+    warning: 3
+
 identifier_name:
   excluded:
     - id

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 #### Enhancements
 
-* None
+* Add a `PreparationStrategy` property to `BackendService` to allow for just-in-time modifications to outgoing `Request`s.
+[Will McGinty](https://github.com/wmcginty)
+[#171](https://github.com/BottleRocketStudios/iOS-Hyperspace/pull/171)
 
 ##### Bug Fixes
 

--- a/Hyperspace.xcodeproj/project.pbxproj
+++ b/Hyperspace.xcodeproj/project.pbxproj
@@ -10,6 +10,18 @@
 		0E2EBCF227692AC300EE8625 /* HTTP.Body.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E2EBCF127692AC300EE8625 /* HTTP.Body.swift */; };
 		0E2EBCF327692AC300EE8625 /* HTTP.Body.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E2EBCF127692AC300EE8625 /* HTTP.Body.swift */; };
 		0E2EBCF427692AC300EE8625 /* HTTP.Body.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E2EBCF127692AC300EE8625 /* HTTP.Body.swift */; };
+		0E30297B2A719B1D00F8A6DA /* PreparationStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E30297A2A719B1D00F8A6DA /* PreparationStrategy.swift */; };
+		0E30297C2A719B1D00F8A6DA /* PreparationStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E30297A2A719B1D00F8A6DA /* PreparationStrategy.swift */; };
+		0E30297D2A719B1D00F8A6DA /* PreparationStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E30297A2A719B1D00F8A6DA /* PreparationStrategy.swift */; };
+		0E30297E2A719B1D00F8A6DA /* PreparationStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E30297A2A719B1D00F8A6DA /* PreparationStrategy.swift */; };
+		0E3029842A719D7300F8A6DA /* PreparationStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E30297F2A719D5400F8A6DA /* PreparationStrategyTests.swift */; };
+		0E3029852A719D7400F8A6DA /* PreparationStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E30297F2A719D5400F8A6DA /* PreparationStrategyTests.swift */; };
+		0E3029862A719D7500F8A6DA /* PreparationStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E30297F2A719D5400F8A6DA /* PreparationStrategyTests.swift */; };
+		0E3029872A719D7500F8A6DA /* PreparationStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E30297F2A719D5400F8A6DA /* PreparationStrategyTests.swift */; };
+		0E30298D2A719F3C00F8A6DA /* Request+Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E3029882A719F3300F8A6DA /* Request+Mock.swift */; };
+		0E30298E2A719F3D00F8A6DA /* Request+Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E3029882A719F3300F8A6DA /* Request+Mock.swift */; };
+		0E30298F2A719F3D00F8A6DA /* Request+Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E3029882A719F3300F8A6DA /* Request+Mock.swift */; };
+		0E3029902A719F3E00F8A6DA /* Request+Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E3029882A719F3300F8A6DA /* Request+Mock.swift */; };
 		0E347E6421599B7D00BF18FA /* XCTestCase+JSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E347E6221599B5900BF18FA /* XCTestCase+JSON.swift */; };
 		0E347E6521599B7F00BF18FA /* XCTestCase+JSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E347E6221599B5900BF18FA /* XCTestCase+JSON.swift */; };
 		0E81B49920AC8E0B00DC1F4E /* RecoveryStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E81B49820AC8E0B00DC1F4E /* RecoveryStrategy.swift */; };
@@ -41,10 +53,10 @@
 		0EC1737329BFBF4B00170BEC /* NetworkActivityControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EC1737029BFBF4B00170BEC /* NetworkActivityControllerTests.swift */; };
 		0EC1737429BFBF4B00170BEC /* NetworkActivityControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EC1737029BFBF4B00170BEC /* NetworkActivityControllerTests.swift */; };
 		0EC1737529BFBF4B00170BEC /* NetworkActivityControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EC1737029BFBF4B00170BEC /* NetworkActivityControllerTests.swift */; };
-		0EC1737629BFBF4B00170BEC /* RecoverableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EC1737129BFBF4B00170BEC /* RecoverableTests.swift */; };
-		0EC1737729BFBF4B00170BEC /* RecoverableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EC1737129BFBF4B00170BEC /* RecoverableTests.swift */; };
-		0EC1737829BFBF4B00170BEC /* RecoverableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EC1737129BFBF4B00170BEC /* RecoverableTests.swift */; };
-		0EC1737929BFBF4B00170BEC /* RecoverableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EC1737129BFBF4B00170BEC /* RecoverableTests.swift */; };
+		0EC1737629BFBF4B00170BEC /* RecoveryStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EC1737129BFBF4B00170BEC /* RecoveryStrategyTests.swift */; };
+		0EC1737729BFBF4B00170BEC /* RecoveryStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EC1737129BFBF4B00170BEC /* RecoveryStrategyTests.swift */; };
+		0EC1737829BFBF4B00170BEC /* RecoveryStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EC1737129BFBF4B00170BEC /* RecoveryStrategyTests.swift */; };
+		0EC1737929BFBF4B00170BEC /* RecoveryStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EC1737129BFBF4B00170BEC /* RecoveryStrategyTests.swift */; };
 		0EC1737D29BFBF5B00170BEC /* DecodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EC1737A29BFBF5B00170BEC /* DecodingTests.swift */; };
 		0EC1737E29BFBF5B00170BEC /* DecodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EC1737A29BFBF5B00170BEC /* DecodingTests.swift */; };
 		0EC1737F29BFBF5B00170BEC /* DecodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EC1737A29BFBF5B00170BEC /* DecodingTests.swift */; };
@@ -232,6 +244,9 @@
 		0E09A39F2790AD1300AB7DD8 /* NOTICE.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = NOTICE.txt; sourceTree = SOURCE_ROOT; };
 		0E09A3A02790AD8F00AB7DD8 /* Hyperspace.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Hyperspace.h; path = Sources/Hyperspace.h; sourceTree = SOURCE_ROOT; };
 		0E2EBCF127692AC300EE8625 /* HTTP.Body.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTP.Body.swift; sourceTree = "<group>"; };
+		0E30297A2A719B1D00F8A6DA /* PreparationStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreparationStrategy.swift; sourceTree = "<group>"; };
+		0E30297F2A719D5400F8A6DA /* PreparationStrategyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreparationStrategyTests.swift; sourceTree = "<group>"; };
+		0E3029882A719F3300F8A6DA /* Request+Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Request+Mock.swift"; sourceTree = "<group>"; };
 		0E347E6221599B5900BF18FA /* XCTestCase+JSON.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+JSON.swift"; sourceTree = "<group>"; };
 		0E666BDF27A0809E001082D0 /* SSL Pinning.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = "SSL Pinning.md"; sourceTree = "<group>"; };
 		0E81B49820AC8E0B00DC1F4E /* RecoveryStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecoveryStrategy.swift; sourceTree = "<group>"; };
@@ -244,7 +259,7 @@
 		0EC1736629BFBF3800170BEC /* HTTPTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTTPTests.swift; sourceTree = "<group>"; };
 		0EC1736729BFBF3800170BEC /* RequestTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestTests.swift; sourceTree = "<group>"; };
 		0EC1737029BFBF4B00170BEC /* NetworkActivityControllerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkActivityControllerTests.swift; sourceTree = "<group>"; };
-		0EC1737129BFBF4B00170BEC /* RecoverableTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecoverableTests.swift; sourceTree = "<group>"; };
+		0EC1737129BFBF4B00170BEC /* RecoveryStrategyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecoveryStrategyTests.swift; sourceTree = "<group>"; };
 		0EC1737A29BFBF5B00170BEC /* DecodingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DecodingTests.swift; sourceTree = "<group>"; };
 		0EC1737B29BFBF5B00170BEC /* EmptyDecodingStrategyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EmptyDecodingStrategyTests.swift; sourceTree = "<group>"; };
 		0EC1737C29BFBF5B00170BEC /* EncodingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EncodingTests.swift; sourceTree = "<group>"; };
@@ -404,6 +419,7 @@
 			isa = PBXGroup;
 			children = (
 				0E81B49820AC8E0B00DC1F4E /* RecoveryStrategy.swift */,
+				0E30297A2A719B1D00F8A6DA /* PreparationStrategy.swift */,
 				B4C32C2B201E9F2D00FC82C1 /* NetworkActivityController.swift */,
 			);
 			path = Peripheral;
@@ -431,7 +447,8 @@
 			isa = PBXGroup;
 			children = (
 				0EC1737029BFBF4B00170BEC /* NetworkActivityControllerTests.swift */,
-				0EC1737129BFBF4B00170BEC /* RecoverableTests.swift */,
+				0EC1737129BFBF4B00170BEC /* RecoveryStrategyTests.swift */,
+				0E30297F2A719D5400F8A6DA /* PreparationStrategyTests.swift */,
 			);
 			path = Peripheral;
 			sourceTree = "<group>";
@@ -606,6 +623,7 @@
 				60D6C3F2201CFCCF00B3B012 /* Mocks */,
 				60D6C3F8201CFCCF00B3B012 /* JSON */,
 				0E347E6221599B5900BF18FA /* XCTestCase+JSON.swift */,
+				0E3029882A719F3300F8A6DA /* Request+Mock.swift */,
 				0E9570912840245400B769E0 /* XCTest+Async.swift */,
 			);
 			path = Helper;
@@ -1019,6 +1037,7 @@
 				0EFFCCAB2790B35800D3FD83 /* BackendService.swift in Sources */,
 				0EFFCCA62790B35500D3FD83 /* Transporting.swift in Sources */,
 				0EFFCC982790B34600D3FD83 /* Request+Decodable.swift in Sources */,
+				0E30297E2A719B1D00F8A6DA /* PreparationStrategy.swift in Sources */,
 				0EFFCCA82790B35500D3FD83 /* TransportResult.swift in Sources */,
 				0EFFCC9B2790B34600D3FD83 /* URL+Additions.swift in Sources */,
 				0EFFCCA42790B35200D3FD83 /* NetworkActivityController.swift in Sources */,
@@ -1044,11 +1063,13 @@
 				0EFFCCED2790B37200D3FD83 /* MockCodableContainer.swift in Sources */,
 				0EFFCCEE2790B37200D3FD83 /* MockTransportSession.swift in Sources */,
 				0EFFCD022790B37B00D3FD83 /* XCTestCase+JSON.swift in Sources */,
-				0EC1737929BFBF4B00170BEC /* RecoverableTests.swift in Sources */,
+				0EC1737929BFBF4B00170BEC /* RecoveryStrategyTests.swift in Sources */,
 				0EFFCCE32790B36D00D3FD83 /* RequestTestDefaults.swift in Sources */,
 				0EFFCCF32790B37200D3FD83 /* MockTransportService.swift in Sources */,
+				0E3029902A719F3E00F8A6DA /* Request+Mock.swift in Sources */,
 				0EC1736B29BFBF3800170BEC /* HTTPTests.swift in Sources */,
 				0EC1738829BFBF5B00170BEC /* EncodingTests.swift in Sources */,
+				0E3029872A719D7500F8A6DA /* PreparationStrategyTests.swift in Sources */,
 				42DFB85E28C7F0F300F742C9 /* MockBackendService.swift in Sources */,
 				0EC1738429BFBF5B00170BEC /* EmptyDecodingStrategyTests.swift in Sources */,
 				0EFFCCB52790B36400D3FD83 /* TransportServiceTests.swift in Sources */,
@@ -1070,11 +1091,13 @@
 				0EFFCCE62790B37200D3FD83 /* MockCodableContainer.swift in Sources */,
 				0EFFCCE72790B37200D3FD83 /* MockTransportSession.swift in Sources */,
 				0EFFCD052790B37C00D3FD83 /* XCTestCase+JSON.swift in Sources */,
-				0EC1737829BFBF4B00170BEC /* RecoverableTests.swift in Sources */,
+				0EC1737829BFBF4B00170BEC /* RecoveryStrategyTests.swift in Sources */,
 				0EFFCCE52790B36E00D3FD83 /* RequestTestDefaults.swift in Sources */,
 				0EFFCCEC2790B37200D3FD83 /* MockTransportService.swift in Sources */,
+				0E30298F2A719F3D00F8A6DA /* Request+Mock.swift in Sources */,
 				0EC1736A29BFBF3800170BEC /* HTTPTests.swift in Sources */,
 				0EC1738729BFBF5B00170BEC /* EncodingTests.swift in Sources */,
+				0E3029862A719D7500F8A6DA /* PreparationStrategyTests.swift in Sources */,
 				42DFB85D28C7F0F300F742C9 /* MockBackendService.swift in Sources */,
 				0EC1738329BFBF5B00170BEC /* EmptyDecodingStrategyTests.swift in Sources */,
 				0EFFCCC72790B36500D3FD83 /* TransportServiceTests.swift in Sources */,
@@ -1094,6 +1117,7 @@
 				60D6C372201CC81100B3B012 /* Request.swift in Sources */,
 				60D6C374201CC81100B3B012 /* Transporting.swift in Sources */,
 				60D6C375201CC81100B3B012 /* TransportSession.swift in Sources */,
+				0E30297B2A719B1D00F8A6DA /* PreparationStrategy.swift in Sources */,
 				0E81B4A220ADE0E100DC1F4E /* JSONCoder+Container.swift in Sources */,
 				60D6C377201CC81100B3B012 /* BackendServicing.swift in Sources */,
 				B4C32C2C201E9F2D00FC82C1 /* NetworkActivityController.swift in Sources */,
@@ -1122,8 +1146,10 @@
 				0ECDC1C420A9EDA500ABF991 /* URLQueryParameterTests.swift in Sources */,
 				0EC1738129BFBF5B00170BEC /* EmptyDecodingStrategyTests.swift in Sources */,
 				65A672F62731991A000E3511 /* TestDecodingError.swift in Sources */,
+				0E30298D2A719F3C00F8A6DA /* Request+Mock.swift in Sources */,
 				0EC1737D29BFBF5B00170BEC /* DecodingTests.swift in Sources */,
-				0EC1737629BFBF4B00170BEC /* RecoverableTests.swift in Sources */,
+				0EC1737629BFBF4B00170BEC /* RecoveryStrategyTests.swift in Sources */,
+				0E3029842A719D7300F8A6DA /* PreparationStrategyTests.swift in Sources */,
 				60D6C40B201CFCCF00B3B012 /* MockCodableContainer.swift in Sources */,
 				0EC1737229BFBF4B00170BEC /* NetworkActivityControllerTests.swift in Sources */,
 				42DFB85B28C7F0F300F742C9 /* MockBackendService.swift in Sources */,
@@ -1143,6 +1169,7 @@
 				B469329124135C1000D2B650 /* TransportResult.swift in Sources */,
 				60D6C387201CCCBE00B3B012 /* HTTP.swift in Sources */,
 				60D6C38A201CCCBE00B3B012 /* Request.swift in Sources */,
+				0E30297D2A719B1D00F8A6DA /* PreparationStrategy.swift in Sources */,
 				60D6C38C201CCCBE00B3B012 /* Transporting.swift in Sources */,
 				60D6C38D201CCCBE00B3B012 /* TransportSession.swift in Sources */,
 				0E81B4A420ADE0E100DC1F4E /* JSONCoder+Container.swift in Sources */,
@@ -1166,6 +1193,7 @@
 				B469329024135C0F00D2B650 /* TransportResult.swift in Sources */,
 				60D6C37E201CCCAE00B3B012 /* Request.swift in Sources */,
 				60D6C380201CCCAE00B3B012 /* Transporting.swift in Sources */,
+				0E30297C2A719B1D00F8A6DA /* PreparationStrategy.swift in Sources */,
 				60D6C381201CCCAE00B3B012 /* TransportSession.swift in Sources */,
 				0E81B4A320ADE0E100DC1F4E /* JSONCoder+Container.swift in Sources */,
 				60D6C383201CCCAE00B3B012 /* BackendServicing.swift in Sources */,
@@ -1194,8 +1222,10 @@
 				0ECDC1C520A9EDA600ABF991 /* URLQueryParameterTests.swift in Sources */,
 				0EC1738229BFBF5B00170BEC /* EmptyDecodingStrategyTests.swift in Sources */,
 				65A672F72731991A000E3511 /* TestDecodingError.swift in Sources */,
+				0E30298E2A719F3D00F8A6DA /* Request+Mock.swift in Sources */,
 				0EC1737E29BFBF5B00170BEC /* DecodingTests.swift in Sources */,
-				0EC1737729BFBF4B00170BEC /* RecoverableTests.swift in Sources */,
+				0EC1737729BFBF4B00170BEC /* RecoveryStrategyTests.swift in Sources */,
+				0E3029852A719D7400F8A6DA /* PreparationStrategyTests.swift in Sources */,
 				60D6C40C201CFCCF00B3B012 /* MockCodableContainer.swift in Sources */,
 				0EC1737329BFBF4B00170BEC /* NetworkActivityControllerTests.swift in Sources */,
 				42DFB85C28C7F0F300F742C9 /* MockBackendService.swift in Sources */,

--- a/Sources/HTTP/HTTP.swift
+++ b/Sources/HTTP/HTTP.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 
-// swiftlint:disable nesting
 /// Represents common components encountered when dealing with HTTP.
 public struct HTTP {
     
@@ -233,7 +232,6 @@ public struct HTTP {
         }
     }
 }
-// swiftlint:enable nesting
 
 // MARK: - Common HTTP Header Field Keys
 public extension HTTP.HeaderKey {

--- a/Sources/Service/Backend/BackendService.swift
+++ b/Sources/Service/Backend/BackendService.swift
@@ -11,20 +11,23 @@ public class BackendService {
     
     // MARK: - Properties
     public let transportService: Transporting
-    public var recoveryStrategies: [RecoveryStrategy]
     public var preparationStrategies: [PreparationStrategy]
-    
+    public var recoveryStrategies: [RecoveryStrategy]
+
     // MARK: - Initializers
-    public convenience init(transportService: Transporting = TransportService(),
-                            recoveryStrategies: RecoveryStrategy..., preparationStratgies: PreparationStrategy...) {
-        self.init(transportService: transportService, recoveryStrategies: recoveryStrategies, preparationStrategies: preparationStratgies)
+    public convenience init(transportService: Transporting = TransportService(), preparationStrategies: PreparationStrategy..., recoveryStrategies: RecoveryStrategy...) {
+        self.init(transportService: transportService, preparationStrategies: preparationStrategies, recoveryStrategies: recoveryStrategies)
     }
-    
-    public init(transportService: Transporting = TransportService(),
-                recoveryStrategies: [RecoveryStrategy], preparationStrategies: [PreparationStrategy]) {
+
+    @available(*, deprecated, renamed: "BackendService.init(transportService:preparationStrategies:recoveryStrategies:)")
+    public convenience init(transportService: Transporting = TransportService(), recoveryStrategies: [RecoveryStrategy]) {
+        self.init(transportService: transportService, preparationStrategies: [], recoveryStrategies: recoveryStrategies)
+    }
+
+    public init(transportService: Transporting = TransportService(), preparationStrategies: [PreparationStrategy], recoveryStrategies: [RecoveryStrategy]) {
         self.transportService = transportService
-        self.recoveryStrategies = recoveryStrategies
         self.preparationStrategies = preparationStrategies
+        self.recoveryStrategies = recoveryStrategies
     }
 }
 

--- a/Sources/Service/Backend/BackendServicing.swift
+++ b/Sources/Service/Backend/BackendServicing.swift
@@ -14,7 +14,7 @@ public protocol BackendServicing {
     /// they are executed in order until one attempts to recover from the failure. If no `RecoveryStrategy` is present, all errors are returned directly to the client.
     var recoveryStrategies: [RecoveryStrategy] { get }
 
-    /// <#Description#>
+    /// Handles any just-in-time modifications to requests before they are executed.
     var preparationStrategies: [PreparationStrategy] { get }
 
     /// Executes the Request, calling the provided completion block when finished.
@@ -40,9 +40,11 @@ public protocol BackendServicing {
 public extension BackendServicing {
 
     var recoveryStrategies: [RecoveryStrategy] { return [] }
-
     var preparationStrategies: [PreparationStrategy] { return [] }
 
+    /// Applies all of the service's attached `PreparationStrategy` to the outgoing request.
+    /// - Parameter request: The request to be executed.
+    /// - Returns: The modified request after applying each `PreparationStrategy` in turn.
     func prepare<R>(toExecute request: Request<R>) async throws -> Request<R> {
         var toBeExecuted = request
         for strategy in preparationStrategies {

--- a/Sources/Service/Backend/BackendServicing.swift
+++ b/Sources/Service/Backend/BackendServicing.swift
@@ -14,6 +14,9 @@ public protocol BackendServicing {
     /// they are executed in order until one attempts to recover from the failure. If no `RecoveryStrategy` is present, all errors are returned directly to the client.
     var recoveryStrategies: [RecoveryStrategy] { get }
 
+    /// <#Description#>
+    var preparationStrategies: [PreparationStrategy] { get }
+
     /// Executes the Request, calling the provided completion block when finished.
     ///
     /// - Parameters:
@@ -35,8 +38,19 @@ public protocol BackendServicing {
 // MARK: - BackendServiceProtocol Default Implementations
 
 public extension BackendServicing {
-    
+
     var recoveryStrategies: [RecoveryStrategy] { return [] }
+
+    var preparationStrategies: [PreparationStrategy] { return [] }
+
+    func prepare<R>(toExecute request: Request<R>) async throws -> Request<R> {
+        var toBeExecuted = request
+        for strategy in preparationStrategies {
+            toBeExecuted = try await strategy.prepare(toExecute: toBeExecuted)
+        }
+
+        return toBeExecuted
+    }
     
     /// Attempt to recover from an error encountered when executing a request.
     /// - Parameters:

--- a/Sources/Service/Peripheral/PreparationStrategy.swift
+++ b/Sources/Service/Peripheral/PreparationStrategy.swift
@@ -14,6 +14,6 @@ public protocol PreparationStrategy {
     /// - Parameter request: The request that is about to be executed
     /// - Returns: A modified version of the `Request` that will be executed.
     ///
-    ///  While this method is both `async` and `throws`, any errors thrown as part of the preparation are not recoverable using any of the`RecoveryStrategy` attached to the executing `BackendService`.
+    ///  While this method is both `async` and `throws`, any errors thrown as part of the preparation are not recoverable using any of the `RecoveryStrategy` attached to the executing `BackendService`.
     func prepare<R>(toExecute request: Request<R>) async throws -> Request<R>
 }

--- a/Sources/Service/Peripheral/PreparationStrategy.swift
+++ b/Sources/Service/Peripheral/PreparationStrategy.swift
@@ -14,6 +14,6 @@ public protocol PreparationStrategy {
     /// - Parameter request: The request that is about to be executed
     /// - Returns: A modified version of the `Request` that will be executed.
     ///
-    ///  While this method is both `async` and `throws`, any errors thrown as part of the preparation are not recoverable using any  of the`RecoveryStrategy` attached to the executing `BackendService`.
+    ///  While this method is both `async` and `throws`, any errors thrown as part of the preparation are not recoverable using any of the`RecoveryStrategy` attached to the executing `BackendService`.
     func prepare<R>(toExecute request: Request<R>) async throws -> Request<R>
 }

--- a/Sources/Service/Peripheral/PreparationStrategy.swift
+++ b/Sources/Service/Peripheral/PreparationStrategy.swift
@@ -10,8 +10,10 @@ import Foundation
 
 public protocol PreparationStrategy {
 
-    /// <#Description#>
-    /// - Parameter request: <#request description#>
-    /// - Returns: <#description#>
+    /// Handle any just-in-time transformations needed on the request before execution.
+    /// - Parameter request: The request that is about to be executed
+    /// - Returns: A modified version of the `Request` that will be executed.
+    ///
+    ///  While this method is both `async` and `throws`, any errors thrown as part of the preparation are not recoverable using any  of the`RecoveryStrategy` attached to the executing `BackendService`.
     func prepare<R>(toExecute request: Request<R>) async throws -> Request<R>
 }

--- a/Sources/Service/Peripheral/PreparationStrategy.swift
+++ b/Sources/Service/Peripheral/PreparationStrategy.swift
@@ -1,0 +1,17 @@
+//
+//  PreparationStrategy.swift
+//  Hyperspace
+//
+//  Created by Will McGinty on 7/26/23.
+//  Copyright © 2023 Bottle Rocket Studios. All rights reserved.
+//
+
+import Foundation
+
+public protocol PreparationStrategy {
+
+    /// <#Description#>
+    /// - Parameter request: <#request description#>
+    /// - Returns: <#description#>
+    func prepare<R>(toExecute request: Request<R>) async throws -> Request<R>
+}

--- a/Tests/Helper/Mocks/MockTransportService.swift
+++ b/Tests/Helper/Mocks/MockTransportService.swift
@@ -31,8 +31,10 @@ extension MockTransportService: Transporting {
         executeCallCount += 1
 
         switch responseResult {
-        case .success(let success): return success
-        case .failure(let failure): throw failure
+        case .success(let success):
+            return .init(response: .init(request: .init(urlRequest: request), code: success.response.code, url: success.response.url, headers: success.response.headers, body: success.response.body))
+        case .failure(let failure):
+            throw TransportFailure(kind: failure.kind, request: .init(urlRequest: request), response: failure.response)
         }
     }
 }

--- a/Tests/Helper/Request+Mock.swift
+++ b/Tests/Helper/Request+Mock.swift
@@ -1,0 +1,26 @@
+//
+//  Request+Mock.swift
+//  Hyperspace
+//
+//  Created by Will McGinty on 7/26/23.
+//  Copyright © 2023 Bottle Rocket Studios. All rights reserved.
+//
+
+import Foundation
+import Hyperspace
+
+// MARK: - Request + Convenience
+extension Request {
+
+    static var simpleGET: Request<String> {
+        return .init(method: .get, url: URL(string: "http://apple.com")!, cachePolicy: .useProtocolCachePolicy, timeout: 1)
+    }
+
+    static var simplePOST: Request<String> {
+        return .init(method: .post, url: URL(string: "http://apple.com")!, cachePolicy: .useProtocolCachePolicy, timeout: 1)
+    }
+
+    static var cachePolicyAndTimeoutRequest: Request<Void> {
+        return .withEmptyResponse(method: .get, url: URL(string: "http://apple.com")!)
+    }
+}

--- a/Tests/Peripheral/PreparationStrategyTests.swift
+++ b/Tests/Peripheral/PreparationStrategyTests.swift
@@ -1,0 +1,38 @@
+//
+//  PreparationStrategyTests.swift
+//  Hyperspace
+//
+//  Created by Will McGinty on 7/26/23.
+//  Copyright © 2023 Bottle Rocket Studios. All rights reserved.
+//
+
+import XCTest
+@testable import Hyperspace
+
+class PreparationStrategyTests: XCTestCase {
+
+    private struct SendDatePreparationStrategy: PreparationStrategy {
+
+        // MARK: - Properties
+        let date: Date
+        let dateFormatter = ISO8601DateFormatter()
+
+        // MARK: - Interface
+        func prepare<R>(toExecute request: Request<R>) async throws -> Request<R> {
+            return request.addingHeaders([.acceptDatetime: .init(rawValue: dateFormatter.string(from: date))])
+        }
+    }
+
+    func testPreparationStrategy_correctlyModifiesIncomingRequest() async throws {
+        let request: Request<String> = .simpleGET
+        let date = Date()
+        let preparationStrategy = SendDatePreparationStrategy(date: date)
+
+        let preparedRequest = try await preparationStrategy.prepare(toExecute: request)
+        XCTAssertEqual(preparedRequest.url, request.url)
+        XCTAssertNil(request.headers)
+        XCTAssertEqual(preparedRequest.headers?.contains(where: { $0.key == .acceptDatetime }), true)
+        XCTAssertEqual(preparedRequest.headers?.first(where: { $0.key == .acceptDatetime })?.value.rawValue,
+                       preparationStrategy.dateFormatter.string(from: date))
+    }
+}

--- a/Tests/Peripheral/PreparationStrategyTests.swift
+++ b/Tests/Peripheral/PreparationStrategyTests.swift
@@ -11,6 +11,7 @@ import XCTest
 
 class PreparationStrategyTests: XCTestCase {
 
+    // MARK: - Subtypes
     private struct SendDatePreparationStrategy: PreparationStrategy {
 
         // MARK: - Properties
@@ -23,6 +24,29 @@ class PreparationStrategyTests: XCTestCase {
         }
     }
 
+    private struct ThrowingPreparationStrategy: PreparationStrategy {
+
+        enum Error: Swift.Error {
+            case invalidPreparation
+        }
+
+        func prepare<R>(toExecute request: Request<R>) async throws -> Request<R> {
+            throw Error.invalidPreparation
+        }
+    }
+
+    // MARK: - Typealias
+
+    typealias DefaultModel = RequestTestDefaults.DefaultModel
+
+    // MARK: - Properties
+
+    private let modelJSONData = RequestTestDefaults.defaultModelJSONData
+    private let defaultRequest: Request<DefaultModel> = RequestTestDefaults.defaultRequest()
+    private lazy var defaultHTTPRequest = HTTP.Request(urlRequest: defaultRequest.urlRequest)
+    private lazy var defaultSuccessResponse = HTTP.Response(request: defaultHTTPRequest, code: 200, body: modelJSONData)
+    private lazy var defaultFailureResponse = HTTP.Response(request: defaultHTTPRequest, code: 500)
+
     func testPreparationStrategy_correctlyModifiesIncomingRequest() async throws {
         let request: Request<String> = .simpleGET
         let date = Date()
@@ -34,5 +58,34 @@ class PreparationStrategyTests: XCTestCase {
         XCTAssertEqual(preparedRequest.headers?.contains(where: { $0.key == .acceptDatetime }), true)
         XCTAssertEqual(preparedRequest.headers?.first(where: { $0.key == .acceptDatetime })?.value.rawValue,
                        preparationStrategy.dateFormatter.string(from: date))
+    }
+
+    func testBackendService_errorsThrownFromPreparationStrategyAreImmediatelyThrownToCaller() async {
+        let transportService = MockTransportService(responseResult: .failure(.init(kind: .unknown, response: defaultFailureResponse)))
+        let backendService = BackendService(transportService: transportService, preparationStrategies: ThrowingPreparationStrategy())
+
+        do {
+            _ = try await backendService.execute(request: .simpleGET)
+            XCTFail("Preparation for execution should fail.")
+        } catch {
+            XCTAssertEqual(transportService.executeCallCount, 0)
+            XCTAssertNil(transportService.lastExecutedURLRequest)
+            XCTAssert(error is ThrowingPreparationStrategy.Error)
+        }
+    }
+
+    func testBackendService_preparationStrategiesAreExecutedInOrder() async throws {
+        let transportService = MockTransportService(responseResult: .success(.init(response: defaultSuccessResponse)))
+        let truePrepStrategy = SendDatePreparationStrategy(date: Date())
+        let backendService = BackendService(transportService: transportService, preparationStrategies: SendDatePreparationStrategy(date: .distantPast), truePrepStrategy)
+
+        let request = defaultRequest.map { transportSuccess, model in
+            XCTAssertEqual(transportSuccess.request.headers?.contains(where: { $0.key == .acceptDatetime }), true)
+            XCTAssertEqual(transportSuccess.request.headers?.first(where: { $0.key == .acceptDatetime })?.value.rawValue,
+                           truePrepStrategy.dateFormatter.string(from: truePrepStrategy.date))
+            return model
+        }
+
+        _ = try await backendService.execute(request: request)
     }
 }

--- a/Tests/Peripheral/RecoveryStrategyTests.swift
+++ b/Tests/Peripheral/RecoveryStrategyTests.swift
@@ -1,5 +1,5 @@
 //
-//  RecoverableTests.swift
+//  RecoveryStrategyTests.swift
 //  Tests
 //
 //  Copyright © 2018 Bottle Rocket Studios. All rights reserved.
@@ -8,7 +8,7 @@
 import XCTest
 @testable import Hyperspace
 
-class RecoverableTests: XCTestCase {
+class RecoveryStrategyTests: XCTestCase {
 
     // MARK: - MockRecoverable Subtype
     struct MockRecoverable: Recoverable {

--- a/Tests/Request/RequestTests.swift
+++ b/Tests/Request/RequestTests.swift
@@ -167,7 +167,7 @@ class RequestTests: XCTestCase {
         }
 
         await XCTAssertNoThrow(try await mapped.transform(success: success))
-        await waitForExpectations(timeout: 1, handler: nil)
+        await fulfillment(of: [exp], timeout: 1)
     }
 
     func test_Request_MappingARequestToANewResponseDoesNotUseHandlerWhenInitialRequestFails() async throws {
@@ -179,7 +179,7 @@ class RequestTests: XCTestCase {
         let mapped: Request<[MockObject]> = request.map { exp.fulfill(); return [$0] }
 
         await XCTAssertThrowsError(try await mapped.transform(success: TransportSuccess(response: response)))
-        await waitForExpectations(timeout: 1, handler: nil)
+        await fulfillment(of: [exp], timeout: 1)
     }
 
     // MARK: - Private
@@ -200,21 +200,5 @@ class RequestTests: XCTestCase {
         XCTAssertEqual(urlRequest.httpBody, body, file: file, line: line)
         XCTAssertEqual(urlRequest.cachePolicy, cachePolicy, file: file, line: line)
         XCTAssertEqual(urlRequest.timeoutInterval, timeout, file: file, line: line)
-    }
-}
-
-// MARK: - Request + Convenience
-private extension Request {
-
-    static var simpleGET: Request<String> {
-        return .init(method: .get, url: URL(string: "http://apple.com")!, cachePolicy: .useProtocolCachePolicy, timeout: 1)
-    }
-
-    static var simplePOST: Request<String> {
-        return .init(method: .post, url: URL(string: "http://apple.com")!, cachePolicy: .useProtocolCachePolicy, timeout: 1)
-    }
-
-    static var cachePolicyAndTimeoutRequest: Request<Void> {
-        return .withEmptyResponse(method: .get, url: URL(string: "http://apple.com")!)
     }
 }


### PR DESCRIPTION
Adds a property on `BackendService` for an array of `PreparationStrategy`. These are executed in order just before every request is sent, allowing for just-in-time modifications to the request before send. They execute `async`, and can `throw`. Errors thrown from a `PreparationStrategy` are not recoverable using the existing`RecoveryStrategy` machinery and throw to the caller immediately (they do not hit the server). This is useful for applying a dynamic property to every request that isn't as simple as setting a common header.

For example
```swift
struct SignatureApplyingPreparationStrategy: PreparationStrategy {

    func prepare<R>(toExecute request: Request<R>) async throws -> Request<R> {
        return request.addingHeaders([.signature: .init(rawValue: applySignature(using: request.url, body: request.body))])
    }

    func applySignature(using url: URL, body: Data?) -> String {
        // ...
    }
}

let backendService = BackendService(preparationStrategies: SignatureApplyingPreparationStrategy())
try await backendService.execute(request: myRequest)
```

Whereas previously this signature would need to be applied to each request, the `PreparationStrategy` allows this logic to reside in one place, apply to all outgoing requests, but still be based on the properties of each individual request.